### PR TITLE
chore: emit event when destroyed

### DIFF
--- a/experimental_notarization/packages/iota_notarization/sources/notarization.move
+++ b/experimental_notarization/packages/iota_notarization/sources/notarization.move
@@ -238,6 +238,7 @@ module iota_notarization::notarization {
     }
 
     // ===== Basic Getter Functions =====
+    public fun state<S: store + drop>(self: &Notarization<S>): &S { &self.state }
     public fun is_locked<S: store + drop>(self: &Notarization<S>): bool { self.immutable_metadata.locking.is_some() }
     public fun created_at<S: store + drop>(self: &Notarization<S>): u64 { self.immutable_metadata.created_at }
     public fun last_change<S: store + drop>(self: &Notarization<S>): u64 { self.last_state_change_at }


### PR DESCRIPTION
# Description of change

These follow suit as the other endpoints! When a notarization is destroyed, we emit event with the object ID. This will help incase a user/validator has subscribed to the Notarization events and would like to be notified incase it is destroyed.


## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes #issue_number`. -->

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
