### PR TITLE
Introduce initial e2e tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ labels: "request"
 body:
 - type: markdown
   attributes:
-    value: Before requesting a feature, please search for existing [feature requests](https://github.com/iotaledger/notarization/labels/request) to avoid creating duplicates.
+    value: Before requesting a feature, please search for existing [feature requests](https://github.com/iotaledger/notarization/issues) to avoid creating duplicates.
 - type: textarea
   id: feature-description
   attributes:

--- a/.github/actions/iota-cli-setup/action.yml
+++ b/.github/actions/iota-cli-setup/action.yml
@@ -29,9 +29,9 @@ runs:
         # url = https://api.github.com/repos/iotaledger/iota/releases/latest
         # releases might be visible before all binaries are available, so refer to fixed binaries here
         if [ "$PLATFORM" = "linux" ]; then
-          DOWNLOAD_URL="https://github.com/iotaledger/iota/releases/download/v0.10.3-rc/iota-v0.10.3-rc-linux-x86_64.tgz"
+          DOWNLOAD_URL="https://github.com/iotaledger/iota/releases/download/v0.11.6-rc/iota-v0.11.6-rc-linux-x86_64.tgz"
         elif [ "$PLATFORM" = "macos" ]; then
-          DOWNLOAD_URL="https://github.com/iotaledger/iota/releases/download/v0.10.3-rc/iota-v0.10.3-rc-macos-arm64.tgz"
+          DOWNLOAD_URL="https://github.com/iotaledger/iota/releases/download/v0.11.6-rc/iota-v0.11.6-rc-macos-arm64.tgz"
           brew install postgresql
           brew reinstall libpq
         else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ members = ["notarization-rs"]
 
 [workspace.dependencies]
 anyhow = "1.0"
+async-trait = "0.1.88"
 cfg-if = "1.0"
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2f502fd8570fe4e9cff36eea5bbd6fef22002898", package = "fastcrypto" }
 identity_iota_core = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", default-features = false, features = [
     "iota-client",
 ], package = "identity_iota_core" }

--- a/notarization-move/Move.toml
+++ b/notarization-move/Move.toml
@@ -7,9 +7,10 @@ edition = "2024.beta"
 
 [dependencies]
 # 'tag' keyword not supported here, therefore use rev instead
-# 'tag = "v0.10.3-rc"' equals 'rev = "21768a84e4fe2815ea7f674db645269ae8546d07"', which we use here
-MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "21768a84e4fe2815ea7f674db645269ae8546d07" }
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "21768a84e4fe2815ea7f674db645269ae8546d07" }
+# 'tag = "v0.11.6-rc"' equals 'rev = "80fc853da5811f842be7bf749d6a981a17c9e565", which we use here
+# 'tag = "v0.10.3-rc"' equals 'rev = "21768a84e4fe2815ea7f674db645269ae8546d07"'
+MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "80fc853da5811f842be7bf749d6a981a17c9e565" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "80fc853da5811f842be7bf749d6a981a17c9e565" }
 
 [addresses]
 iota_notarization = "0x0"

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -22,20 +22,19 @@ serde_json.workspace = true
 thiserror.workspace = true
 strum.workspace = true
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 identity_iota_interaction.workspace = true
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v0.10.3-rc" }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.10.3-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.10.3-rc" }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.2.0" }
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.10.3-rc" }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v0.11.6-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v0.11.6-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v0.11.6-rc" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v0.11.6-rc" }
 tokio = { version = "1.29.0", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 identity_iota_interaction = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", package = "identity_iota_interaction", default-features = false }
 iota_interaction_ts = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", package = "iota_interaction_ts" }
-secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.2.0" }
+secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.identity_iota_core]
 git = "https://github.com/iotaledger/identity.rs.git"
@@ -43,3 +42,11 @@ branch = "feat/identity-rebased-alpha-public-interaction-rust"
 package = "identity_iota_core"
 default-features = false
 features = ["iota-client", "revocation-bitmap"]
+
+[dev-dependencies]
+async-trait.workspace = true
+identity_jose = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", package = "identity_jose" }
+identity_storage = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", package = "identity_storage", features = ["send-sync-storage", "storage-signer"] }
+identity_iota_interaction = { git = "https://github.com/iotaledger/identity.rs.git", branch = "feat/identity-rebased-alpha-public-interaction-rust", package = "identity_iota_interaction", features = ["keytool-signer"] }
+lazy_static = "1.5.0"
+

--- a/notarization-rs/src/client_tools.rs
+++ b/notarization-rs/src/client_tools.rs
@@ -1,20 +1,105 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::Output;
+use anyhow::Context;
 use identity_iota_core::iota_interaction_adapter::IotaClientAdapter;
 use identity_iota_core::network::NetworkName;
-use identity_iota_interaction::IotaClientTrait;
-
 use crate::error::Error;
+
+use identity_iota_interaction::IotaClientTrait;
+use identity_iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use serde::Deserialize;
+use tokio::process::Command;
+
+const FUND_WITH_ACTIVE_ADDRESS_FUNDING_TX_BUDGET: u64 = 5_000_000;
+const FUND_WITH_ACTIVE_ADDRESS_FUNDING_VALUE: u64 = 500_000_000;
 
 /// Returns the network-id also known as chain-identifier provided by the specified iota_client
 pub async fn network_id(iota_client: &IotaClientAdapter) -> Result<NetworkName, Error> {
     let network_id = iota_client
-        .read_api()
-        .get_chain_identifier()
-        .await
-        .map_err(|e| Error::RpcError(e.to_string()))?;
-    Ok(network_id
-        .try_into()
-        .expect("chain ID is a valid network name"))
+      .read_api()
+      .get_chain_identifier()
+      .await
+      .map_err(|e| Error::RpcError(e.to_string()))?;
+    Ok(network_id.try_into().expect("chain ID is a valid network name"))
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CoinOutput {
+    gas_coin_id: ObjectID,
+    nanos_balance: u64,
+}
+
+fn unpack_command_output(output: &Output, task: &str) -> anyhow::Result<String> {
+    let stdout = std::str::from_utf8(&output.stdout)?;
+    if !output.status.success() {
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        anyhow::bail!("Failed to {task}: {stdout}, {stderr}");
+    }
+
+    Ok(stdout.to_string())
+}
+
+/// Requests funds from the local IOTA client's configured faucet.
+///
+/// This behavior can be changed to send funds with local IOTA client's active address to the given address.
+/// For that the env variable `IOTA_IDENTITY_FUND_WITH_ACTIVE_ADDRESS` must be set to `true`.
+/// Notice, that this is a setting mostly intended for internal test use and must be used with care.
+/// For details refer to to `identity_iota_core`'s README.md.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn request_funds(address: &IotaAddress) -> anyhow::Result<()> {
+    let fund_with_active_address = std::env::var("IOTA_IDENTITY_FUND_WITH_ACTIVE_ADDRESS")
+      .map(|v| !v.is_empty() && v.to_lowercase() == "true")
+      .unwrap_or(false);
+
+    if !fund_with_active_address {
+        let output = Command::new("iota")
+          .arg("client")
+          .arg("faucet")
+          .arg("--address")
+          .arg(address.to_string())
+          .arg("--json")
+          .output()
+          .await
+          .context("Failed to execute command")?;
+        unpack_command_output(&output, "request funds from faucet")?;
+    } else {
+        let output = Command::new("iota")
+          .arg("client")
+          .arg("gas")
+          .arg("--json")
+          .output()
+          .await
+          .context("Failed to execute command")?;
+        let output_str = unpack_command_output(&output, "fetch active account's gas coins")?;
+
+        let parsed: Vec<CoinOutput> = serde_json::from_str(&output_str)?;
+        let min_balance = FUND_WITH_ACTIVE_ADDRESS_FUNDING_VALUE + FUND_WITH_ACTIVE_ADDRESS_FUNDING_TX_BUDGET;
+        let matching = parsed.into_iter().find(|coin| coin.nanos_balance >= min_balance);
+        let Some(coin_to_use) = matching else {
+            anyhow::bail!("Failed to find coin object with enough funds to transfer to test account");
+        };
+
+        let address_string = address.to_string();
+        let output = Command::new("iota")
+          .arg("client")
+          .arg("pay-iota")
+          .arg("--recipients")
+          .arg(&address_string)
+          .arg("--input-coins")
+          .arg(coin_to_use.gas_coin_id.to_string())
+          .arg("--amounts")
+          .arg(FUND_WITH_ACTIVE_ADDRESS_FUNDING_VALUE.to_string())
+          .arg("--gas-budget")
+          .arg(FUND_WITH_ACTIVE_ADDRESS_FUNDING_TX_BUDGET.to_string())
+          .arg("--json")
+          .output()
+          .await
+          .context("Failed to execute command")?;
+        unpack_command_output(&output, &format!("send funds from active account to {address_string}"))?;
+    }
+
+    Ok(())
 }

--- a/notarization-rs/src/lib.rs
+++ b/notarization-rs/src/lib.rs
@@ -1,10 +1,12 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod client_tools;
 pub mod error;
 pub mod notarization;
 
-mod client_tools;
 pub mod core;
 mod iota_interaction_adapter;
 mod well_known_networks;
+
+pub use notarization::*;

--- a/notarization-rs/tests/e2e/common.rs
+++ b/notarization-rs/tests/e2e/common.rs
@@ -1,0 +1,277 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+#![allow(dead_code)]
+
+use lazy_static::lazy_static;
+use anyhow::anyhow;
+use anyhow::Context;
+
+use identity_jose::jwk::Jwk;
+use identity_jose::jws::JwsAlgorithm;
+use identity_storage::JwkMemStore;
+use identity_storage::JwkStorage;
+use identity_storage::KeyId;
+use identity_storage::KeyIdMemstore;
+use identity_storage::KeyIdStorage;
+use identity_storage::KeyType;
+use identity_storage::MethodDigest;
+use identity_storage::Storage;
+use identity_storage::StorageSigner;
+use identity_iota_core::rebased::transaction::Transaction;
+use identity_iota_interaction::{IotaClient, IotaClientBuilder, IOTA_LOCAL_NETWORK_URL};
+use identity_iota_interaction::types::crypto::SignatureScheme;
+use secret_storage::Signer;
+use serde::Deserialize;
+use serde_json::Value;
+use std::io::Write;
+use std::str::FromStr;
+use std::sync::Arc;
+use identity_iota_interaction::IotaKeySignature;
+use identity_iota_interaction::keytool_signer::KeytoolSigner;
+use identity_iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use move_core_types::language_storage::StructTag;
+use tokio::process::Command;
+use tokio::sync::OnceCell;
+
+use notarization::client_tools::request_funds;
+
+pub type MemStorage = Storage<JwkMemStore, KeyIdMemstore>;
+pub type MemSigner<'s> = StorageSigner<'s, JwkMemStore, KeyIdMemstore>;
+
+static PACKAGE_ID: OnceCell<ObjectID> = OnceCell::const_new();
+const SCRIPT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/");
+const CACHED_PRODUCT_PKG_ID: &str = "/tmp/iota_product_pkg_id.txt";
+
+pub const TEST_GAS_BUDGET: u64 = 50_000_000;
+
+lazy_static! {
+  pub static ref TEST_COIN_TYPE: StructTag = "0x2::coin::Coin<bool>".parse().unwrap();
+}
+
+pub struct InitialAccountData<S: Signer<IotaKeySignature>> {
+  pub signer: S,
+  pub iota_client: IotaClient,
+}
+
+async fn init_package(iota_client: &IotaClient) -> anyhow::Result<ObjectID> {
+  let network_id = iota_client.read_api().get_chain_identifier().await?;
+  let address = get_active_address().await?;
+
+  if let Ok(id) = std::env::var("IOTA_PRODUCT_PKG_ID").or(get_cached_product_pkg_id(&network_id).await) {
+    std::env::set_var("IOTA_PRODUCT_PKG_ID", id.clone());
+    id.parse().context("failed to parse object id from str")
+  } else {
+    publish_package(address).await
+  }
+}
+
+async fn get_cached_product_pkg_id(network_id: &str) -> anyhow::Result<String> {
+  let cache = tokio::fs::read_to_string(CACHED_PRODUCT_PKG_ID).await?;
+  let (cached_id, cached_network_id) = cache.split_once(';').ok_or(anyhow!("Invalid or empty cached data"))?;
+
+  if cached_network_id == network_id {
+    Ok(cached_id.to_owned())
+  } else {
+    Err(anyhow!("A network change has invalidated the cached data"))
+  }
+}
+
+/// Returns the default address of the IOTA CLI installed on the local system (`iota client active-address`)
+async fn get_active_address() -> anyhow::Result<IotaAddress> {
+  Command::new("iota")
+    .arg("client")
+    .arg("active-address")
+    .arg("--json")
+    .output()
+    .await
+    .context("Failed to execute command")
+    .and_then(|output| Ok(serde_json::from_slice::<IotaAddress>(&output.stdout)?))
+}
+
+async fn publish_package(active_address: IotaAddress) -> anyhow::Result<ObjectID> {
+  let output = Command::new("sh")
+    .current_dir(SCRIPT_DIR)
+    .arg("publish_identity_package.sh")
+    .output()
+    .await?;
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+
+  if !output.status.success() {
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    anyhow::bail!("Failed to publish move package: \n\n{stdout}\n\n{stderr}");
+  }
+
+  let package_id: ObjectID = {
+    let stdout_trimmed = stdout.trim();
+    ObjectID::from_str(stdout_trimmed).with_context(|| {
+      let stderr = std::str::from_utf8(&output.stderr).unwrap();
+      format!("failed to find IDENTITY_IOTA_PKG_ID in response from: '{stdout_trimmed}'; {stderr}")
+    })?
+  };
+
+  // Persist package ID in order to avoid publishing the package for every test.
+  let package_id_str = package_id.to_string();
+  std::env::set_var("IDENTITY_IOTA_PKG_ID", package_id_str.as_str());
+  let mut file = std::fs::File::create(CACHED_PRODUCT_PKG_ID)?;
+  write!(&mut file, "{};{}", package_id_str, active_address)?;
+
+  Ok(package_id)
+}
+
+pub async fn get_key_data() -> Result<(Storage<JwkMemStore, KeyIdMemstore>, KeyId, Jwk, Vec<u8>), anyhow::Error> {
+  let storage = Storage::<JwkMemStore, KeyIdMemstore>::new(JwkMemStore::new(), KeyIdMemstore::new());
+  let generate = storage
+    .key_storage()
+    .generate(KeyType::new("Ed25519"), JwsAlgorithm::EdDSA)
+    .await?;
+  let public_key_jwk = generate.jwk.to_public().expect("public components should be derivable");
+  let public_key_bytes = get_public_key_bytes(&public_key_jwk)?;
+  // let sender_address = convert_to_address(&public_key_bytes)?;
+
+  Ok((storage, generate.key_id, public_key_jwk, public_key_bytes))
+}
+
+fn get_public_key_bytes(sender_public_jwk: &Jwk) -> Result<Vec<u8>, anyhow::Error> {
+  let public_key_base_64 = &sender_public_jwk
+    .try_okp_params()
+    .map_err(|err| anyhow!("key not of type `Okp`; {err}"))?
+    .x;
+
+  identity_jose::jwu::decode_b64(public_key_base_64).map_err(|err| anyhow!("could not decode base64 public key; {err}"))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GasObjectHelper {
+  nanos_balance: u64,
+}
+
+async fn get_balance(address: IotaAddress) -> anyhow::Result<u64> {
+  let output = Command::new("iota")
+    .arg("client")
+    .arg("gas")
+    .arg("--json")
+    .arg(address.to_string())
+    .output()
+    .await?;
+
+  if !output.status.success() {
+    let error_msg = String::from_utf8(output.stderr)?;
+    anyhow::bail!("failed to get balance: {error_msg}");
+  }
+
+  let balance = serde_json::from_slice::<Vec<GasObjectHelper>>(&output.stdout)?
+    .into_iter()
+    .map(|gas_info| gas_info.nanos_balance)
+    .sum();
+
+  Ok(balance)
+}
+
+#[derive(Clone)]
+pub struct TestClient {
+  client: Arc<IotaClient>,
+  signer: Arc<KeytoolSigner>,
+  product_pkg_id: ObjectID,
+  storage: Arc<MemStorage>,
+}
+
+impl TestClient {
+  pub async fn new() -> anyhow::Result<Self> {
+    let active_address = get_active_address().await?;
+    Self::new_from_address(active_address).await
+  }
+
+  pub async fn new_from_address(address: IotaAddress) -> anyhow::Result<Self> {
+    let api_endpoint = std::env::var("API_ENDPOINT").unwrap_or_else(|_| IOTA_LOCAL_NETWORK_URL.to_string());
+    println!("api_endpoint: {}", api_endpoint);
+    let iota_client = IotaClientBuilder::default().build(&api_endpoint).await?;
+    let product_pkg_id = PACKAGE_ID.get_or_try_init(|| init_package(&iota_client)).await.copied()?;
+
+    let balance = get_balance(address).await?;
+    if balance < TEST_GAS_BUDGET {
+      request_funds(&address).await?;
+    }
+
+    let storage = Arc::new(Storage::new(JwkMemStore::new(), KeyIdMemstore::new()));
+    // Create a signer using the currently active address of the iota CLI (default)
+    let signer = KeytoolSigner::builder().build().await?;
+
+    Ok(TestClient {
+      client: Arc::new(iota_client),
+      signer: Arc::new(signer),
+      product_pkg_id,
+      storage,
+    })
+  }
+
+  pub async fn get_funded_client_account(&self) -> anyhow::Result<InitialAccountData<MemSigner>> {
+    let storage = Arc::new(Storage::new(JwkMemStore::new(), KeyIdMemstore::new()));
+    let generate = storage
+      .key_storage()
+      .generate(KeyType::new("Ed25519"), JwsAlgorithm::EdDSA)
+      .await?;
+    let public_key_jwk = generate.jwk.to_public().expect("public components should be derivable");
+    let signer = StorageSigner::new(&self.storage, generate.key_id, public_key_jwk);
+    let public_key = <MemSigner as Signer<IotaKeySignature>>::public_key(&signer).await?;
+
+    request_funds(&IotaAddress::from(&public_key)).await?;
+
+    Ok(InitialAccountData{signer, iota_client: (*self.client).clone() })
+  }
+
+
+  pub async fn new_with_key_type(key_type: SignatureScheme) -> anyhow::Result<Self> {
+    let address = make_address(key_type).await?;
+    Self::new_from_address(address).await
+  }
+
+  pub fn package_id(&self) -> ObjectID {
+    self.product_pkg_id
+  }
+
+  pub fn signer(&self) -> &KeytoolSigner {
+    &self.signer
+  }
+}
+
+pub async fn make_address(key_type: SignatureScheme) -> anyhow::Result<IotaAddress> {
+  if !matches!(
+    key_type,
+    SignatureScheme::ED25519 | SignatureScheme::Secp256k1 | SignatureScheme::Secp256r1
+  ) {
+    anyhow::bail!("key type {key_type} is not supported");
+  }
+
+  let output = Command::new("iota")
+    .arg("client")
+    .arg("new-address")
+    .arg("--key-scheme")
+    .arg(key_type.to_string())
+    .arg("--json")
+    .output()
+    .await?;
+  let new_address = {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let start_of_json = stdout.find('{').ok_or_else(|| {
+      let stderr = std::str::from_utf8(&output.stderr).unwrap();
+      anyhow!("No json in output: '{stdout}'; {stderr}",)
+    })?;
+    let json_result = serde_json::from_str::<Value>(stdout[start_of_json..].trim())?;
+    let address_str = json_result
+      .get("address")
+      .context("no address in JSON output")?
+      .as_str()
+      .context("address is not a JSON string")?;
+
+    address_str.parse()?
+  };
+
+  request_funds(&new_address).await?;
+
+  Ok(new_address)
+}
+
+pub async fn get_funded_test_client() -> anyhow::Result<TestClient> {
+  TestClient::new().await
+}

--- a/notarization-rs/tests/e2e/dynamic_notarization.rs
+++ b/notarization-rs/tests/e2e/dynamic_notarization.rs
@@ -1,0 +1,16 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::get_funded_test_client;
+use crate::new_builder;
+
+#[tokio::test]
+async fn create_dynamic_notarization() -> anyhow::Result<()>{
+  let mut test_client = get_funded_test_client().await?;
+  let builder = new_builder(&mut test_client).await?;
+  let dyn_notarization = builder.create_dynamic().await?;
+
+ // assert!(dyn_notarization.did_document().metadata.deactivated == Some(true));
+
+  Ok(())
+}

--- a/notarization-rs/tests/e2e/main.rs
+++ b/notarization-rs/tests/e2e/main.rs
@@ -1,0 +1,67 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use identity_storage::StorageSigner;
+use identity_storage::JwkMemStore;
+use identity_storage::KeyIdMemstore;
+use identity_iota_interaction::IotaKeySignature;
+use identity_iota_interaction::types::base_types::ObjectID;
+use identity_iota_interaction::keytool_signer::KeytoolSigner;
+use iota_sdk::IotaClient;
+use secret_storage::Signer;
+use tokio::sync::OnceCell;
+use notarization::{Notarization, NotarizationBuilder};
+
+use crate::common::{MemSigner, TestClient, InitialAccountData};
+
+mod common;
+mod dynamic_notarization;
+
+/*
+#[async_trait]
+impl<S: Signer<IotaKeySignature>> ProductT for NotarizationBuilder<S> {
+  async fn new<P>(iota_client: IotaClient, signer: impl Signer<IotaKeySignature>) -> anyhow::Result<NotarizationBuilder<S>> {
+    let builder = NotarizationBuilder::new(iota_client).await?
+      .signer(signer);
+    Ok(builder)
+  }
+
+  async fn new_with_pkg_id(iota_client: IotaClient, signer: impl Signer<IotaKeySignature>, iota_product_pkg_id: ObjectID) -> anyhow::Result<Self::FullProduct> {
+    let builder = NotarizationBuilder::new_with_pkg_id(iota_client, iota_product_pkg_id).await?
+      .signer(signer);
+    Ok(builder)
+  }
+
+  async fn new_read_only(iota_client: IotaClient) -> anyhow::Result<Self::ReadOnlyProduct> {
+    Ok(NotarizationBuilder::new_read_only(iota_client).await?)
+  }
+
+  async fn new_read_only_with_pkg_id(iota_client: IotaClient, iota_product_pkg_id: ObjectID) -> anyhow::Result<Self::ReadOnlyProduct> {
+    Ok(NotarizationBuilder::new_read_only_with_pkg_id(iota_client, iota_product_pkg_id).await?)
+  }
+
+  fn as_full_ref(&self) -> &Self::FullProduct {
+    todo!()
+  }
+
+  fn as_read_only_ref(&self) -> &Self::ReadOnlyProduct {
+    todo!()
+  }
+
+  fn as_full_ref_mut(&mut self) -> &mut Self::FullProduct {
+    todo!()
+  }
+
+  fn as_read_only_ref_mut(&mut self) -> &mut Self::ReadOnlyProduct {
+    todo!()
+  }
+}
+*/
+
+async fn new_builder(test_client: &mut TestClient) -> anyhow::Result<NotarizationBuilder<MemSigner>> {
+  let user_account_data = test_client.get_funded_client_account().await?;
+  let builder = NotarizationBuilder::new(user_account_data.iota_client.clone()).await?
+    .signer(user_account_data.signer);
+  Ok(builder)
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,9 @@
 imports_granularity = "Module"
 group_imports = "StdExternalCrate"
+comment_width = 120
+format_code_in_doc_comments = true
+max_width = 120
+normalize_comments = false
+normalize_doc_attributes = false
+tab_spaces = 4
+wrap_comments = true


### PR DESCRIPTION
# Description of change

This PR provides a raw but run-able Notarization e2e test frame. For currently unknown reasons the test fails with `Error: No such file or directory (os error 2)` which needs to be fixed later on.

The version of IOTA dependencies has been pined to "v0.11.6-rc"

## Type of change

Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo test --package notarization --test e2e
```
