### PR TITLE
New GH workflow `Wasm re-tag npm`

### DIFF
--- a/.github/workflows/wasm-retag-npm.yml
+++ b/.github/workflows/wasm-retag-npm.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   release-wasm:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
# Description of change

Needed to re-tag version tags on npm e.g., for moving tags.