### PR TITLE
Implicit Move dependencies

### DIFF
--- a/notarization-move/Move.toml
+++ b/notarization-move/Move.toml
@@ -6,13 +6,6 @@ name = "IotaNotarization"
 edition = "2024.beta"
 
 [dependencies]
-# 'tag' keyword not supported here, therefore use rev instead
-
-# 'tag = "v1.2.3"' equals 'rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910"', which we use here
-# Version-Tag-History:
-# * v0.12.0-rc - "7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
-MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
 
 [addresses]
 iota_notarization = "0x0"


### PR DESCRIPTION
Use implicit dependencies instead of explicit for official IOTA packages.

:warning: This cannot be merged before IOTA version v.1.4.1 hits mainnet.
