### PR TITLE
Fix finish() function return type information

### DIFF
--- a/bindings/wasm/notarization_wasm/src/wasm_notarization_builder.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_notarization_builder.rs
@@ -85,7 +85,7 @@ impl WasmNotarizationBuilderLocked {
     ///
     /// # Returns
     /// A `TransactionBuilder` to build and execute the transaction.
-    #[wasm_bindgen()]
+    #[wasm_bindgen(unchecked_return_type = "TransactionBuilder<CreateNotarizationLocked>")]
     pub fn finish(self) -> Result<WasmTransactionBuilder> {
         let js_value: JsValue = WasmCreateNotarizationLocked::new(self).into();
         Ok(WasmTransactionBuilder::new(js_value.unchecked_into()))
@@ -165,7 +165,7 @@ impl WasmNotarizationBuilderDynamic {
     ///
     /// # Returns
     /// A `TransactionBuilder` to build and execute the transaction.
-    #[wasm_bindgen()]
+    #[wasm_bindgen(unchecked_return_type = "TransactionBuilder<CreateNotarizationDynamic>")]
     pub fn finish(self) -> Result<WasmTransactionBuilder> {
         let js_value: JsValue = WasmCreateNotarizationDynamic::new(self).into();
         Ok(WasmTransactionBuilder::new(js_value.unchecked_into()))


### PR DESCRIPTION
# Description of change

The `finish()` functions of `WasmNotarizationBuilderLocked` and `WasmNotarizationBuilderDynamic` provide correct type information now.

The correct type information allows TS users to profit from IDE type augmentation and code completion. This also applies to problems with finding the `executeWithGasStation` function.

## Links to any relevant issues

* fixes #93 
* fixes #80

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Build the notarization JS/Typescript bindings 
```
cd bindings/wasm/notarization_wasm
npm install
npm build:nodejs
```

Try to use the `executeWithGasStation` function in one of the TS examples (bindings/wasm/notarization_wasm/examples/src/...).

