### PR TITLE
Use IOTA v1.4.1 + product-core 0.8.0 and @iota/iota-interaction-ts 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["bindings/wasm/notarization_wasm"]
 anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.2.3" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction" }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction_rust" }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction_ts" }
@@ -26,7 +26,7 @@ strum = { version = "0.27", default-features = false, features = ["std", "derive
 thiserror = { version = "2.0", default-features = false }
 
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0", default-features = false }
-tokio = { version = "1.44.2", default-features = false, features = ["macros", "sync", "rt", "process"] }
+tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [profile.release.package.iota_interaction_ts]
 opt-level = 's'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.95"
 async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2f502fd8570fe4e9cff36eea5bbd6fef22002898", package = "fastcrypto" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", package = "iota_interaction", default-features = false }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
@@ -30,7 +30,7 @@ serde-wasm-bindgen = "0.6.5"
 serde_json = { version = "1.0", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
 # Want to use the nice API of tokio::sync::RwLock for now even though we can't use threads.
-tokio = { version = "1.44.2", default-features = false, features = ["sync"] }
+tokio = { version = "1.46.1", default-features = false, features = ["sync"] }
 tsify = "0.4.5"
 wasm-bindgen = { version = "0.2.100", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.7.0", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.7.0"
+tag = "v0.8.0"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@iota/iota-interaction-ts": "^0.7.0"
+        "@iota/iota-interaction-ts": "^0.8.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@iota/iota-interaction-ts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.7.0.tgz",
-      "integrity": "sha512-1MLT3J2hiaoeBuUEyGEn4oP01NbWYcSr3EdYTkB7cEiVgnPzW0dQfj6N08Xw8QUqK4Ns3d2l0aR5f9Vn3zxY9w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.8.0.tgz",
+      "integrity": "sha512-FxihkQA7ah0wB3/TbXTaEpOvJu9Jt1D+43oTNxuVCAvYfNT2rm3yeR5dEtNN5iGK+5GnK66MK0gmcWzFHFzEYQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -72,7 +72,7 @@
     "wasm-opt": "^1.4.0"
   },
   "dependencies": {
-    "@iota/iota-interaction-ts": "^0.7.0"
+    "@iota/iota-interaction-ts": "^0.8.0"
   },
   "peerDependencies": {
     "@iota/iota-sdk": "^1.2.0"

--- a/notarization-move/Move.toml
+++ b/notarization-move/Move.toml
@@ -6,13 +6,6 @@ name = "IotaNotarization"
 edition = "2024.beta"
 
 [dependencies]
-# 'tag' keyword not supported here, therefore use rev instead
-
-# 'tag = "v1.2.3"' equals 'rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910"', which we use here
-# Version-Tag-History:
-# * v0.12.0-rc - "7e49c58b826b34c8e2b61842ef13c8de35a0aee8"
-MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
 
 [addresses]
 iota_notarization = "0x0"

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iota_interaction_ts.workspace = true
-tokio = { version = "1.44.2", default-features = false, features = ["sync"] }
+tokio = { version = "1.46.1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/notarization-rs/src/client/read_only.rs
+++ b/notarization-rs/src/client/read_only.rs
@@ -329,7 +329,7 @@ impl NotarizationClientReadOnly {
                 metadata: state.metadata,
             })
         } else {
-            return Err(Error::InvalidArgument(format!("Unsupported state type: {type_str}")));
+            Err(Error::InvalidArgument(format!("Unsupported state type: {type_str}")))
         }
     }
 


### PR DESCRIPTION
# Description of change

This PR includes:
* Update Move.toml - Use the implicit dependencies instead of explicit for official IOTA packages
* Pin iota to tag "v1.4.1" 
* Pin tokio to "1.46.1" (1.46 semver compatible)
* Pin fastcrypto to rev="69d496c71fb37e3d22fe85e5bbfd4256d61422b9" as being used by IOTA 1.4.1
* Pin rust product-core dependencies to "v0.8.0" (released today)
* Identity-Wasm: Pin `@iota/iota-interaction-ts` dependency version to "^0.8.0"

## Links to any relevant issues

fixes #110

## Type of change

- [] Bug fix (a non-breaking change which fixes an issue)
- [x ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
