### PR TITLE
feat: Access `IotaTransactionBlockResponse` returned by `build_and_execute`

### DIFF
--- a/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
@@ -19,7 +19,9 @@ export async function createLocked(): Promise<void> {
 
     // create a new Locked Notarization
     console.log("Building a simple locked notarization and publish it to the IOTA network");
-    const { output: notarization } = await notarizationClient
+    // Create a locked notarization with state and delete lock - we will not only access the returned OnChainNotarization
+    // later on, but also the returned IotaTransactionBlockResponse containing the transaction details.
+    const { output: notarization, response: response } = await notarizationClient
         .createLocked()
         // Control the type of State data by choosing one of the `with...State` functions below.
         // Uncomment or comment the following lines to choose between string or byte State data.
@@ -36,7 +38,7 @@ export async function createLocked(): Promise<void> {
         .finish()
         .buildAndExecute(notarizationClient);
 
-    console.log("\n✅ Locked notarization created successfully!");
+    console.log(`✅ Locked notarization created successfully with TX digest ${response.digest}!`);
 
     // check some important properties of the received OnChainNotarization
     console.log("\n----------------------------------------------------");

--- a/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
@@ -19,7 +19,9 @@ export async function createDynamic(): Promise<void> {
 
     // create a new Dynamic Notarization
     console.log("Building a dynamic notarization with transferLock and publish it to the IOTA network");
-    const { output: notarization } = await notarizationClient
+    // Create a dynamic notarization with transferLock - we will not only access the returned OnChainNotarization
+    // later on, but also the returned IotaTransactionBlockResponse containing the transaction details.
+    const { output: notarization, response: response } = await notarizationClient
         .createDynamic()
         // Control the type of State data by choosing one of the `with...State` functions below.
         // Uncomment or comment the following lines to choose between string or byte State data.
@@ -33,7 +35,7 @@ export async function createDynamic(): Promise<void> {
         .finish()
         .buildAndExecute(notarizationClient);
 
-    console.log("\n✅ Successfully created a transfer locked Dynamic notarization!");
+    console.log(`✅ Transfer locked Dynamic notarization created successfully with TX digest ${response.digest}!`);
 
     // check some important properties of the received OnChainNotarization
     console.log("\n----------------------------------------------------");

--- a/examples/01_create_locked_notarization.rs
+++ b/examples/01_create_locked_notarization.rs
@@ -41,7 +41,8 @@ async fn main() -> Result<()> {
 
     println!(
         "✅ Locked notarization created successfully with TX digest \"{}\" at timestamp [ms]: {}!",
-        response.digest, response.timestamp_ms.unwrap_or_else(|| 0)
+        response.digest,
+        response.timestamp_ms.unwrap_or(0)
     );
     println!("Notarization ID: {:?}", locked_notarization.id);
     println!("Method: {:?}", locked_notarization.method);

--- a/examples/01_create_locked_notarization.rs
+++ b/examples/01_create_locked_notarization.rs
@@ -5,7 +5,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use examples::get_funded_client;
-use notarization::core::types::{NotarizationMethod, State, TimeLock};
+use notarization::core::types::{NotarizationMethod, OnChainNotarization, State, TimeLock};
+use product_common::transaction::TransactionOutput;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,8 +21,12 @@ async fn main() -> Result<()> {
 
     println!("Creating locked notarization with delete lock until: {unlock_at}");
 
-    // Create a locked notarization with state and delete lock
-    let locked_notarization = notarization_client
+    // Create a locked notarization with state and delete lock - we will not only access the returned
+    // OnChainNotarization later on, but also the response containing the transaction details.
+    let TransactionOutput::<OnChainNotarization> {
+        output: locked_notarization,
+        response,
+    } = notarization_client
         .create_locked_notarization()
         .with_state(State::from_string(
             "Important document content".to_string(),
@@ -32,10 +37,12 @@ async fn main() -> Result<()> {
         .with_delete_lock(TimeLock::UnlockAt(unlock_at as u32))
         .finish()?
         .build_and_execute(&notarization_client)
-        .await?
-        .output;
+        .await?;
 
-    println!("✅ Locked notarization created successfully!");
+    println!(
+        "✅ Locked notarization created successfully with TX digest \"{}\" at timestamp [ms]: {}!",
+        response.digest, response.timestamp_ms.unwrap_or_else(|| 0)
+    );
     println!("Notarization ID: {:?}", locked_notarization.id);
     println!("Method: {:?}", locked_notarization.method);
     println!("Description: {:?}", locked_notarization.immutable_metadata.description);

--- a/examples/02_create_dynamic_notarization.rs
+++ b/examples/02_create_dynamic_notarization.rs
@@ -4,9 +4,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use product_common::transaction::TransactionOutput;
 use examples::get_funded_client;
 use notarization::core::types::{NotarizationMethod, OnChainNotarization, State, TimeLock};
+use product_common::transaction::TransactionOutput;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,8 +17,8 @@ async fn main() -> Result<()> {
 
     println!("Creating a simple dynamic notarization without locks...");
 
-    // Create a simple dynamic notarization - we will not only store the returned OffchainNotarization,
-    // but also the response containing the transaction details.
+    // Create a simple dynamic notarization - we will not only access the returned
+    // OnChainNotarization later on, but also the response containing the transaction details.
     let TransactionOutput::<OnChainNotarization> {
         output: simple_notarization,
         response
@@ -34,12 +34,11 @@ async fn main() -> Result<()> {
         .build_and_execute(&notarization_client)
         .await?;
 
-    println!("✅ Simple dynamic notarization created!");
+    println!(
+        "✅ Simple dynamic notarization created successfully with TX digest \"{}\" at timestamp [ms]: {}!",
+        response.digest, response.timestamp_ms.unwrap_or_else(|| 0)
+    );
     println!("ID: {:?}", simple_notarization.id);
-    
-    // Print the response details
-    println!("Response TX digest: {:?}", response.digest);
-    println!("Response timestamp [ms]: {:?}", response.timestamp_ms);
 
     // Calculate unlock time for transfer lock example
     let now_ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();

--- a/examples/02_create_dynamic_notarization.rs
+++ b/examples/02_create_dynamic_notarization.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     // OnChainNotarization later on, but also the response containing the transaction details.
     let TransactionOutput::<OnChainNotarization> {
         output: simple_notarization,
-        response
+        response,
     } = notarization_client
         .create_dynamic_notarization()
         .with_state(State::from_string(
@@ -36,7 +36,8 @@ async fn main() -> Result<()> {
 
     println!(
         "✅ Simple dynamic notarization created successfully with TX digest \"{}\" at timestamp [ms]: {}!",
-        response.digest, response.timestamp_ms.unwrap_or_else(|| 0)
+        response.digest,
+        response.timestamp_ms.unwrap_or(0)
     );
     println!("ID: {:?}", simple_notarization.id);
 

--- a/notarization-move/Move.lock
+++ b/notarization-move/Move.lock
@@ -2,56 +2,36 @@
 
 [move]
 version = 3
-manifest_digest = "2E3FF0C8C2529AC5F5521920800D3385F4B722FF03E524F5AF757E81CA710024"
-deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
+manifest_digest = "2FA64AE578ECFADFE6576D98160FEBC1DFF70895E34236A183F6833371359743"
+deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Iota", name = "Iota" },
-  { id = "IotaSystem", name = "IotaSystem" },
   { id = "MoveStdlib", name = "MoveStdlib" },
-  { id = "Stardust", name = "Stardust" },
 ]
 
 [[move.package]]
 id = "Iota"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/iota-framework" }
+source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/iota-framework" }
 
 dependencies = [
-  { id = "MoveStdlib", name = "MoveStdlib" },
-]
-
-[[move.package]]
-id = "IotaSystem"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/iota-system" }
-
-dependencies = [
-  { id = "Iota", name = "Iota" },
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/move-stdlib" }
-
-[[move.package]]
-id = "Stardust"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/stardust" }
-
-dependencies = [
-  { id = "Iota", name = "Iota" },
-  { id = "MoveStdlib", name = "MoveStdlib" },
-]
+source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.4.1"
+compiler-version = "1.2.3"
 edition = "2024.beta"
 flavor = "iota"
 
 [env]
 
 [env.localnet]
-chain-id = "2cd5f6a7"
-original-published-id = "0x0229fe320d1f7bcdb605efd13949f2bb5d11e23086899b45a0a8fa0c6596bd6f"
-latest-published-id = "0x0229fe320d1f7bcdb605efd13949f2bb5d11e23086899b45a0a8fa0c6596bd6f"
+chain-id = "ecc0606a"
+original-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
+latest-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
 published-version = "1"
 
 [env.devnet]

--- a/notarization-move/Move.lock
+++ b/notarization-move/Move.lock
@@ -2,36 +2,56 @@
 
 [move]
 version = 3
-manifest_digest = "2FA64AE578ECFADFE6576D98160FEBC1DFF70895E34236A183F6833371359743"
-deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
+manifest_digest = "2E3FF0C8C2529AC5F5521920800D3385F4B722FF03E524F5AF757E81CA710024"
+deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
+dependencies = [
+  { id = "Iota", name = "Iota" },
+  { id = "IotaSystem", name = "IotaSystem" },
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Stardust", name = "Stardust" },
+]
+
+[[move.package]]
+id = "Iota"
+source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/iota-framework" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+]
+
+[[move.package]]
+id = "IotaSystem"
+source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/iota-system" }
+
 dependencies = [
   { id = "Iota", name = "Iota" },
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [[move.package]]
-id = "Iota"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/iota-framework" }
+id = "MoveStdlib"
+source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/move-stdlib" }
+
+[[move.package]]
+id = "Stardust"
+source = { git = "https://github.com/iotaledger/iota.git", rev = "e3c45c9370f14b8137fd1bb9d109d3563d416223", subdir = "crates/iota-framework/packages/stardust" }
 
 dependencies = [
+  { id = "Iota", name = "Iota" },
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
-[[move.package]]
-id = "MoveStdlib"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/move-stdlib" }
-
 [move.toolchain-version]
-compiler-version = "1.2.3"
+compiler-version = "1.4.1"
 edition = "2024.beta"
 flavor = "iota"
 
 [env]
 
 [env.localnet]
-chain-id = "ecc0606a"
-original-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
-latest-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
+chain-id = "2cd5f6a7"
+original-published-id = "0x0229fe320d1f7bcdb605efd13949f2bb5d11e23086899b45a0a8fa0c6596bd6f"
+latest-published-id = "0x0229fe320d1f7bcdb605efd13949f2bb5d11e23086899b45a0a8fa0c6596bd6f"
 published-version = "1"
 
 [env.devnet]


### PR DESCRIPTION
# Description of change

Extend examples `01_create_locked_notarization` and `02_create_dynamic_notarization` for Rust and TS to also access the IotaTransactionBlockResponse returned by `build_and_execute`.

## Links to any relevant issues

fixes #92

## Type of change

- [] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Locally run all effected examples