### PR TITLE
IOTA v1.5.0-rc - Test with product core feature branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["bindings/wasm/notarization_wasm"]
 anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction" }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_rust" }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", default-features = false, package = "iota_interaction_ts" }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.0"
+branch = "feat/iota-v1-5-0-rc-upstream-merge"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 


### PR DESCRIPTION
> [!WARNING]
> DON'T MERGE THIS PULL REQUEST
>
> This PR is only used to run CI tests against the `product-core` branch `feat/iota-v1-5-0-rc-upstream-merge`

Wasm CI tests will probably be OK but will use the old [0.8.0 version of the @iota/iota-interaction-ts package](https://www.npmjs.com/package/@iota/iota-interaction-ts/v/0.8.0). A new release for the `@iota/iota-interaction-ts` npmjs package is not needed. Therefore these test can be considered as a final evaluation.

The branch used for this PR is based on the IOTA v1-5-0-rc integration branch: https://github.com/iotaledger/notarization/tree/feat/iota-v1-5-0-r