### PR TITLE
Add getter functions for `State` and `LockMetadata` fields

### DIFF
--- a/notarization-move/sources/notarization.move
+++ b/notarization-move/sources/notarization.move
@@ -72,6 +72,19 @@ public struct LockMetadata has store {
     transfer_lock: TimeLock,
 }
 
+// ===== Getter Functions =====
+public fun update_lock(self: &LockMetadata): &TimeLock {
+    &self.update_lock
+}
+
+public fun delete_lock(self: &LockMetadata): &TimeLock {
+    &self.delete_lock
+}
+
+public fun transfer_lock(self: &LockMetadata): &TimeLock {
+    &self.transfer_lock
+}
+
 // ===== Notarization State =====
 /// Represents the state of a Notarization that can be updated
 /// Contains arbitrary data and metadata that can be updated by the owner
@@ -80,6 +93,15 @@ public struct State<D: store + drop + copy> has copy, drop, store {
     data: D,
     /// Mutable metadata that can be updated together with the state data
     metadata: Option<String>,
+}
+
+// ===== Getter Functions =====
+public fun data<D: store + drop + copy>(self: &State<D>): &D {
+    &self.data
+}
+
+public fun metadata<D: store + drop + copy>(self: &State<D>): &Option<String> {
+    &self.metadata
 }
 
 // ===== Event Types =====


### PR DESCRIPTION
## Description of change

<!-- Please write a summary of your changes and why you made them. -->

Adds getter functions to access fields of `State` and `LockMetadata` onchain.

## Type of change

<!-- Choose a type of change from the list below -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

Used getters in a project that consumes notarizations, ran notarization tests locally after added them.

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
