### PR TITLE
Release: Version 0.1.5 and npmjs version 0.1.4

### DIFF
--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization_wasm"
-version = "0.1.4-alpha"
+version = "0.1.5-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iota/notarization",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iota/notarization",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@iota/iota-interaction-ts": "^0.8.0"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -3,7 +3,7 @@
   "author": "IOTA Foundation <info@iota.org>",
   "description": "WASM bindings for IOTA Notarization - A Data Notarization Framework providing multiple notarization methods. To be used in JavaScript/TypeScript",
   "homepage": "https://www.iota.org",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.1.4-alpha"
+version = "0.1.5-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 publish = false

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization"
-version = "0.1.4-alpha"
+version = "0.1.5-alpha"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description of change

* Bump all cargo packages to version 0.1.5
* Bump notarization_wasm package.json version to 0.1.4

## Links to any relevant issues
None

## Release Notes

* New real-world examples (IoT Weather Station and Legal Contract)
* Supports IOTA v1.6.1 and "@iota/iota-sdk" npmjs package version "1.6.1"
* Enhanced documentation for the mutability/immutability behavior of the notarization fields for the Move, Rust and TS interface