### PR TITLE
Release: Version 0.1.7 and npmjs version 0.1.5

### DIFF
--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization_wasm"
-version = "0.1.6-alpha"
+version = "0.1.7-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iota/notarization",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iota/notarization",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@iota/iota-interaction-ts": "^0.8.0"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -3,7 +3,7 @@
   "author": "IOTA Foundation <info@iota.org>",
   "description": "WASM bindings for IOTA Notarization - A Data Notarization Framework providing multiple notarization methods. To be used in JavaScript/TypeScript",
   "homepage": "https://www.iota.org",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.1.6-alpha"
+version = "0.1.7-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 publish = false

--- a/notarization-move/Move.lock
+++ b/notarization-move/Move.lock
@@ -2,56 +2,36 @@
 
 [move]
 version = 3
-manifest_digest = "2E3FF0C8C2529AC5F5521920800D3385F4B722FF03E524F5AF757E81CA710024"
-deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
+manifest_digest = "2FA64AE578ECFADFE6576D98160FEBC1DFF70895E34236A183F6833371359743"
+deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Iota", name = "Iota" },
-  { id = "IotaSystem", name = "IotaSystem" },
   { id = "MoveStdlib", name = "MoveStdlib" },
-  { id = "Stardust", name = "Stardust" },
 ]
 
 [[move.package]]
 id = "Iota"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "bc1cbaf1049b94dde6f0b0cb9af89547132194c3", subdir = "crates/iota-framework/packages/iota-framework" }
+source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/iota-framework" }
 
 dependencies = [
-  { id = "MoveStdlib", name = "MoveStdlib" },
-]
-
-[[move.package]]
-id = "IotaSystem"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "bc1cbaf1049b94dde6f0b0cb9af89547132194c3", subdir = "crates/iota-framework/packages/iota-system" }
-
-dependencies = [
-  { id = "Iota", name = "Iota" },
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "bc1cbaf1049b94dde6f0b0cb9af89547132194c3", subdir = "crates/iota-framework/packages/move-stdlib" }
-
-[[move.package]]
-id = "Stardust"
-source = { git = "https://github.com/iotaledger/iota.git", rev = "bc1cbaf1049b94dde6f0b0cb9af89547132194c3", subdir = "crates/iota-framework/packages/stardust" }
-
-dependencies = [
-  { id = "Iota", name = "Iota" },
-  { id = "MoveStdlib", name = "MoveStdlib" },
-]
+source = { git = "https://github.com/iotaledger/iota.git", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910", subdir = "crates/iota-framework/packages/move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.7.0"
+compiler-version = "1.2.3"
 edition = "2024.beta"
 flavor = "iota"
 
 [env]
 
 [env.localnet]
-chain-id = "fb230e5b"
-original-published-id = "0xb02cc7a0846b0cc12877559b43bf67a1df97c2e53fe8a989145cce78b513bdf3"
-latest-published-id = "0xb02cc7a0846b0cc12877559b43bf67a1df97c2e53fe8a989145cce78b513bdf3"
+chain-id = "ecc0606a"
+original-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
+latest-published-id = "0xfbddb4631d027b2c4f0b4b90c020713d258ed32bdb342b5397f4da71edb7478a"
 published-version = "1"
 
 [env.devnet]
@@ -62,8 +42,8 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "2304aa97"
-original-published-id = "0x29f58d88d9f4d023d94b6c6e871897dfe6a7f246784e7e24f7b63e0bbee48cf7"
-latest-published-id = "0x29f58d88d9f4d023d94b6c6e871897dfe6a7f246784e7e24f7b63e0bbee48cf7"
+original-published-id = "0x00412bd469b7f980227c6c574090348239852e43aa07818b315854fdd8a2d25f"
+latest-published-id = "0x00412bd469b7f980227c6c574090348239852e43aa07818b315854fdd8a2d25f"
 published-version = "1"
 
 [env.mainnet]

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization"
-version = "0.1.6-alpha"
+version = "0.1.7-alpha"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description of change

* Bump all cargo packages to v0.1.7-alpha
* Bump notarization_wasm package.json version to 0.1.5
* Revert move.lock file to rev [86aca13a09fed4d2cb68cf3ce3290bde53bace93](https://github.com/iotaledger/notarization/pull/143/commits/86aca13a09fed4d2cb68cf3ce3290bde53bace93) as we will not update/publish the move code with this release

## Links to any relevant issues
None

## Release Notes

* Enable browser tests - Including Cypress integration and new example applications for notarization plus node-polyfills integration in notarization examples - PR #142 + #141 - Fixes #57
* Add support for IOTA Resource Locators (IRLs) - PR #137