### PR TITLE
Release: Version 0.1.11 - Rust only

### DIFF
--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization_wasm"
-version = "0.1.10-alpha"
+version = "0.1.11-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.1.10-alpha"
+version = "0.1.11-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 publish = false

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notarization"
-version = "0.1.10-alpha"
+version = "0.1.11-alpha"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description of change

* Bump cargo versions to "0.1.11"
* No npmjs release needed. The new introduced `Move.history.json` file will be used by the `PackageRegistry` only in Rust for now. Accompanying the first Notarization package upgrade, an npmjs release of `@iota/notarization` is needed.