### PR TITLE
Fix UntilDestroyed documentation and update notarization-rs/README.md

### DIFF
--- a/bindings/wasm/notarization_wasm/src/wasm_time_lock.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_time_lock.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 /// This enum defines the possible types of time locks that can be applied to a notarization object.
 /// - `None`: No time lock is applied.
 /// - `UnlockAt`: The object will unlock at a specific timestamp.
-/// - `UntilDestroyed`: The object remains locked until it is destroyed.
+/// - `UntilDestroyed`: The object remains locked until it is destroyed. Can not be used for `delete_lock`.
 #[wasm_bindgen(js_name = TimeLockType)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WasmTimeLockType {

--- a/examples/07_transfer_dynamic_notarization.rs
+++ b/examples/07_transfer_dynamic_notarization.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<()> {
     println!("\n📋 Transfer Rules Summary:");
     println!("✅ Unlocked dynamic notarizations can be transferred freely");
     println!("🔒 Transfer-locked dynamic notarizations cannot be transferred until lock expires");
-    println!("🚫 Locked notarizations can never be transferred (transfer_lock = UntilDestroyed)");
+    println!("🚫 Locked notarizations can never be transferred (transfer_lock, update_lock, delete_lock)");
     println!("⏰ Transfer locks are time-based and will expire automatically");
     println!("🔍 Use is_transfer_locked() to check transfer status before attempting");
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -90,7 +90,7 @@ The following examples demonstrate practical use cases with proper field usage:
 
 - **None**: Can be destroyed immediately
 - **UnlockAt(timestamp)**: Cannot be destroyed until timestamp
-- **UntilDestroyed**: Cannot be destroyed (permanent)
+- Please note: **UntilDestroyed**: Cannot be used for Delete Locks
 
 ## Key Concepts
 

--- a/notarization-move/sources/timelock.move
+++ b/notarization-move/sources/timelock.move
@@ -25,7 +25,7 @@ const ETimelockNotExpired: u64 = 1;
 public enum TimeLock has store {
     /// A lock that unlocks at a specific Unix timestamp (seconds since epoch)
     UnlockAt(u32),
-    /// A permanent lock that never unlocks (can't be used for locking delete)
+    /// A permanent lock that never unlocks until the notarization object is destroyed (can't be used for `delete_lock`)
     UntilDestroyed,
     /// No lock applied
     None,
@@ -40,7 +40,7 @@ public fun unlock_at(unix_time: u32, clock: &Clock): TimeLock {
     TimeLock::UnlockAt(unix_time)
 }
 
-/// Creates a new UntilDestroyed lock that never unlocks.
+/// Creates a new UntilDestroyed lock that never unlocks until the notarization object is destroyed.
 public fun until_destroyed(): TimeLock {
     TimeLock::UntilDestroyed
 }

--- a/notarization-rs/src/core/types/timelock.rs
+++ b/notarization-rs/src/core/types/timelock.rs
@@ -12,7 +12,7 @@
 //! ## Types
 //!
 //! - `UnlockAt`: The lock is unlocked at a specific time.
-//! - `UntilDestroyed`: The lock is unlocked when the notarization is destroyed.
+//! - `UntilDestroyed`: The lock is locked until the notarization is destroyed.
 //! - `None`: The lock is not applied.
 
 use std::str::FromStr;


### PR DESCRIPTION
# Description of change

According to the issue #156 the docs in this codebase have been reviewed by searching for specific keywords and checking the docs text in the surrounding context.

The resulting text now should clearly describe that:

* `UntilDestroyed` can not be used for `delete_lock`s
* Notarizations can not be infinitely permanent
* `delete_lock`s are optional for Locked Notarizations

Additionally the outdated process flow diagrams in the `notarization-rs/README.md` have been updated to visualize the current workflow based on the `product_common` types `CoreClient`, `Transaction` and `TransactionBuilder`. 

## Links to any relevant issues

Fixes #156
