### PR TITLE
feat: Update to iota v1.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ bcs = "0.1"
 # Latest hyper is not compatible with axum-server used by iota-sdk. We need to pin it to 1.7 until iota-sdk upgrades axum-server.
 hyper = "=1.7" # Fix for iota-sdk 1.13 issue with axum-server.
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.14.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-14-0-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.9", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-14-0-rc-upstream-merge"
+tag = "v0.8.9"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@iota/iota-interaction-ts": "^0.10.0"
+        "@iota/iota-interaction-ts": "^0.11.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -312,15 +312,15 @@
       }
     },
     "node_modules/@iota/iota-interaction-ts": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.10.0.tgz",
-      "integrity": "sha512-oOSVb+EAOZ+gqBylVf2tj9kYNvir/E3Q9cbMCozaE1yFyk0jFOgfkCoUUgSJgeQJlwwu1jBM8RqTOLlKOchKVw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.11.0.tgz",
+      "integrity": "sha512-lk2OlYlbBW11/csD6+T4UIc4Z/P1THNnu4HtDWHOBVpxKtEqfGodhugCVLqHpcGu0ikVgIgzny4SKoB3LYJQmA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.9.1"
+        "@iota/iota-sdk": "^1.10.1"
       }
     },
     "node_modules/@iota/iota-sdk": {

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -72,7 +72,7 @@
     "wasm-opt": "^1.4.0"
   },
   "dependencies": {
-    "@iota/iota-interaction-ts": "^0.10.0"
+    "@iota/iota-interaction-ts": "^0.11.0"
   },
   "peerDependencies": {
     "@iota/iota-sdk": "^1.10.1"


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] notarization_wasm: new peerDep. version for @iota/iota-sdk:  `1.10.1`
- [x] pin all product-core.git dependencies to `tag = "v0.8.9"`
- [x] pin all iota.git dependencies to `tag = "v1.14.1"``

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67
