### PR TITLE
Fix incompatibility to on-chain packages

### DIFF
--- a/notarization-move/sources/notarization.move
+++ b/notarization-move/sources/notarization.move
@@ -92,19 +92,6 @@ public struct LockMetadata has store {
     transfer_lock: TimeLock,
 }
 
-// ===== Getter Functions =====
-public fun update_lock(self: &LockMetadata): &TimeLock {
-    &self.update_lock
-}
-
-public fun delete_lock(self: &LockMetadata): &TimeLock {
-    &self.delete_lock
-}
-
-public fun transfer_lock(self: &LockMetadata): &TimeLock {
-    &self.transfer_lock
-}
-
 // ===== Notarization State =====
 /// Represents the state of a `Notarization` containing the notarized `data` and its `metadata`
 ///
@@ -120,15 +107,6 @@ public struct State<D: store + drop + copy> has copy, drop, store {
     data: D,
     /// State-associated metadata
     metadata: Option<String>,
-}
-
-// ===== Getter Functions =====
-public fun data<D: store + drop + copy>(self: &State<D>): &D {
-    &self.data
-}
-
-public fun metadata<D: store + drop + copy>(self: &State<D>): &Option<String> {
-    &self.metadata
 }
 
 // ===== Event Types =====


### PR DESCRIPTION
# Description of change

Reverts latest Move changes introduced with commit [1edab04](https://github.com/iotaledger/notarization/commit/1edab0465b51680e83c6abf6f078df892dd9aef2).

At the moment there are backward compatible changes in the Notarization Move code that cause the following error

> jq: parse error: Invalid numeric literal at line 1, column 7
Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at 00412bd469b7f980227c6c574090348239852e43aa07818b315854fdd8a2d25f::IotaNotarization::notarization

if the on-chain Notarization package is used as dependency and the `iota client publish` option `--verify-deps` is used to publish the package using this dependency.

To make the main branch compatible with the on-chain published version again this, PR reverts the incompatible changes.

The reverted changes will be moved into a feature branch with a future PR. 


## How the change has been tested

Publish-tests on testnet have been done using an example provided in the [use-notarization-as-move-dep](https://github.com/iotaledger/notarization/tree/feat/use-notarization-as-move-dep) branch. 

The example package has been successfully [published on testnet](https://explorer.iota.org/object/0x52bb3a74a0ef36bc403dd8b9602a023e0e5c8b7a9f79a4b037f14320d970eafa?network=testnet) using this PR branch as dependency.