### PR TITLE
feat: Update to iota v1.19.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.18.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false, package = "product_common" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction" }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.13"
+branch = "feat/iota-v1-19-rc-upstream-merge"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-19-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-19-rc-upstream-merge"
+tag = "v0.8.14"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = -
- [ ] notarization_wasm: new peerDep. version for @iota/iota-sdk: _
- [ ] notarization_wasm: new dependency version for @iota/iota-interaction-ts: _
- [x] pin all product-core.git dependencies to `tag = "v0.8.14"`
- [x] pin all iota.git dependencies to `tag = "v1.19.1"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67