### PR TITLE
New getters for state.data `valueType` and `valueByteSize`

### DIFF
--- a/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
@@ -47,7 +47,7 @@ export async function createLocked(): Promise<void> {
     console.log("Notarization ID: ", notarization.id);
     console.log("Notarization Method: ", notarization.method);
     console.log("State data value type: ", notarization.state.data.valueType);
-    console.log("State data value length: ", notarization.state.data.valueLength);
+    console.log("State data value byte size: ", notarization.state.data.valueByteSize);
     console.log(
         notarization.state.data.valueType === "String"
             ? `State data as string: "${notarization.state.data.toString()}"`

--- a/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
@@ -58,7 +58,6 @@ export async function createLocked(): Promise<void> {
     console.log("Immutable locking metadata: ", notarization.immutableMetadata.locking);
     console.log("Updatable metadata: ", notarization.updatableMetadata);
     console.log("State version count: ", notarization.stateVersionCount);
-    console.log("State version count: ", notarization.stateVersionCount);
     console.log("Owner: ", notarization.owner);
     // This is what the complete OnChainNotarization looks like
     console.log("\n----------------------------------------------------");

--- a/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/01_create_locked.ts
@@ -46,13 +46,18 @@ export async function createLocked(): Promise<void> {
     console.log("----------------------------------------------------");
     console.log("Notarization ID: ", notarization.id);
     console.log("Notarization Method: ", notarization.method);
+    console.log("State data value type: ", notarization.state.data.valueType);
+    console.log("State data value length: ", notarization.state.data.valueLength);
     console.log(
-        `State data as string: "${notarization.state.data.toString()}" or as bytes: [${notarization.state.data.toBytes()}]`,
+        notarization.state.data.valueType === "String"
+            ? `State data as string: "${notarization.state.data.toString()}"`
+            : `State data as bytes: [${notarization.state.data.toBytes()}]`,
     );
     console.log("State metadata: ", notarization.state.metadata);
     console.log("Immutable description: ", notarization.immutableMetadata.description);
     console.log("Immutable locking metadata: ", notarization.immutableMetadata.locking);
     console.log("Updatable metadata: ", notarization.updatableMetadata);
+    console.log("State version count: ", notarization.stateVersionCount);
     console.log("State version count: ", notarization.stateVersionCount);
     console.log("Owner: ", notarization.owner);
     // This is what the complete OnChainNotarization looks like

--- a/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
@@ -42,6 +42,8 @@ export async function createDynamic(): Promise<void> {
     console.log("----------------------------------------------------");
     console.log("Notarization ID: ", notarization.id);
     console.log("Notarization Method: ", notarization.method);
+    console.log("State data value type: ", notarization.state.data.valueType);
+    console.log("State data value length: ", notarization.state.data.valueLength);
     console.log(
         `State data as string: "${notarization.state.data.toString()}" or as bytes: [${notarization.state.data.toBytes()}]`,
     );

--- a/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/02_create_dynamic.ts
@@ -43,7 +43,7 @@ export async function createDynamic(): Promise<void> {
     console.log("Notarization ID: ", notarization.id);
     console.log("Notarization Method: ", notarization.method);
     console.log("State data value type: ", notarization.state.data.valueType);
-    console.log("State data value length: ", notarization.state.data.valueLength);
+    console.log("State data value byte size: ", notarization.state.data.valueByteSize);
     console.log(
         `State data as string: "${notarization.state.data.toString()}" or as bytes: [${notarization.state.data.toBytes()}]`,
     );

--- a/bindings/wasm/notarization_wasm/examples/src/08_access_read_only_methods.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/08_access_read_only_methods.ts
@@ -43,6 +43,8 @@ export async function accessReadOnlyMethods(): Promise<void> {
     // 3. Get current state
     const currentState = await notarizationClientReadOnly.state(dynamicNotarization.id);
     console.log("📄 State content:", currentState.data.toString());
+    console.log("📄 State data type:", currentState.data.valueType);
+    console.log("📄 State data length:", currentState.data.valueLength);
     console.log("📄 State metadata:", currentState.metadata);
 
     // 4. Get creation timestamp

--- a/bindings/wasm/notarization_wasm/examples/src/08_access_read_only_methods.ts
+++ b/bindings/wasm/notarization_wasm/examples/src/08_access_read_only_methods.ts
@@ -44,7 +44,7 @@ export async function accessReadOnlyMethods(): Promise<void> {
     const currentState = await notarizationClientReadOnly.state(dynamicNotarization.id);
     console.log("📄 State content:", currentState.data.toString());
     console.log("📄 State data type:", currentState.data.valueType);
-    console.log("📄 State data length:", currentState.data.valueLength);
+    console.log("📄 State data byte size:", currentState.data.valueByteSize);
     console.log("📄 State metadata:", currentState.metadata);
 
     // 4. Get creation timestamp

--- a/bindings/wasm/notarization_wasm/src/wasm_types.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_types.rs
@@ -35,6 +35,32 @@ impl WasmData {
         }
     }
 
+    /// Retrieves the type of the value as `String`.
+    ///
+    /// # Returns:
+    /// * `Uint8Array` for binary values
+    /// * `String` for string values
+    #[wasm_bindgen(getter, js_name = valueType)]
+    pub fn value_type(&self) -> String {
+        match &self.0 {
+            Data::Bytes(_) => "Uint8Array".to_string(),
+            Data::Text(_) => "String".to_string(),
+        }
+    }
+
+    /// Retrieves the length of the value as `number`.
+    ///
+    /// # Returns:
+    /// * The number of bytes for binary values
+    /// * The number of characters for string values
+    #[wasm_bindgen(getter, js_name = valueLength)]
+    pub fn value_length(&self) -> usize {
+        match &self.0 {
+            Data::Bytes(bytes) => bytes.len(),
+            Data::Text(text) => text.len(),
+        }
+    }
+
     /// Converts the data to a string representation.
     ///
     /// # Returns

--- a/bindings/wasm/notarization_wasm/src/wasm_types.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_types.rs
@@ -53,7 +53,7 @@ impl WasmData {
     /// # Returns:
     /// * For `Uint8Array` values: The number of bytes in the Uint8Array
     /// * For `String` values: The length of the String, in bytes
-    #[wasm_bindgen(getter, js_name = valueLength)]
+    #[wasm_bindgen(getter, js_name = valueByteSize)]
     pub fn value_byte_size(&self) -> usize {
         match &self.0 {
             Data::Bytes(bytes) => bytes.len(),

--- a/bindings/wasm/notarization_wasm/src/wasm_types.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_types.rs
@@ -48,13 +48,13 @@ impl WasmData {
         }
     }
 
-    /// Retrieves the length of the value as `number`.
+    /// Retrieves the byte size of the value.
     ///
     /// # Returns:
-    /// * The number of bytes for binary values
-    /// * The number of characters for string values
+    /// * For `Uint8Array` values: The number of bytes in the Uint8Array
+    /// * For `String` values: The length of the String, in bytes
     #[wasm_bindgen(getter, js_name = valueLength)]
-    pub fn value_length(&self) -> usize {
+    pub fn value_byte_size(&self) -> usize {
         match &self.0 {
             Data::Bytes(bytes) => bytes.len(),
             Data::Text(text) => text.len(),


### PR DESCRIPTION
# Description of change

This PR provides new getters for notarization state.data:
* `valueType`
* `valueLength`

Usage is demonstrated in the example files which are part of this changeset. 


## Links to any relevant issues

#229

## Type of change

<!-- Choose a type of change from the list below -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

New getters function are used in several examples tested in the CI tests
