### PR TITLE
Remove unnecessary store ability from AuditTrail struct

### DIFF
--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -70,7 +70,7 @@ public struct ImmutableMetadata has copy, drop, store {
 /// It maintains an ordered sequence of records, each assigned a unique
 /// auto-incrementing sequence number.
 /// Uses capability-based RBAC to manage access to the trail and its records.
-public struct AuditTrail<D: store + copy> has key, store {
+public struct AuditTrail<D: store + copy> has key {
     id: UID,
     /// Address that created this trail
     creator: address,


### PR DESCRIPTION
AuditTrail is only ever used as a top-level shared object via transfer::share_object. It is never wrapped in another struct or stored as a dynamic field, so the store ability serves no purpose and unnecessarily expands the public API surface of the type.

# Description of change

<!-- Please write a summary of your changes and why you made them. -->

## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes #issue_number`. -->

## Type of change

<!-- Choose a type of change from the list below -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
