### PR TITLE
feat: Update to iota 96196f0 - yanked core2 fix for v1.21.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.21.1-rc" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction" }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction_rust" }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction_ts" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.21.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction" }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
 iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.21.1-rc" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false, package = "product_common" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.21.1" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.15"
+branch = "feat/iota-v1-21-rc-upstream-merge"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-21-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-21-rc-upstream-merge"
+tag = "v0.8.16"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@iota/iota-interaction-ts": "^0.12.0"
+        "@iota/iota-interaction-ts": "^0.13.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -312,15 +312,15 @@
       }
     },
     "node_modules/@iota/iota-interaction-ts": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.12.0.tgz",
-      "integrity": "sha512-qGGn7DMpzDHCzdrvV4QWUXE1u/5UzX5Y7pWX9RNGkhlerD7gPk01abf4XjfmEhRkN3S2L7YBpnXK34LA6ZzC9w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.13.0.tgz",
+      "integrity": "sha512-LL4nbgEbqqa3UqXkiAnbRMW3KSqKMic0cJEEooWlTz2VtwHSOHyVwzjF2HNt7C9o2svq5uKyCkkzVAxjMI1Esg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.11.0"
+        "@iota/iota-sdk": "^1.13.0"
       }
     },
     "node_modules/@iota/iota-sdk": {

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -35,7 +35,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.11.0"
+        "@iota/iota-sdk": "^1.13.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@iota/bcs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.5.0.tgz",
-      "integrity": "sha512-/hv395YtUcRNLY00v7Cl2O+KvVUaUajg4OucZENgSE4Xu1ygUGsLD3dU5FixOUVOn7Abo+n7+KYr9PE/1dsvWg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.6.0.tgz",
+      "integrity": "sha512-H8I9g+aPBQigSsHkydnnR6wmmTwOwI7iu/TghTOz6tikqVFM09cA2JlDQXRLDTSkW3Qlz6gONyVKzrBhoTkHxQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -324,14 +324,14 @@
       }
     },
     "node_modules/@iota/iota-sdk": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.11.0.tgz",
-      "integrity": "sha512-Fveg/4euheaBUzU1ybPyFGe7sSfLFUjLNHhPjNFUmSBOMR+l9q3LU1QdN2sLElcmgJZ+BLxAEmL8TZ0eX3Khpw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.13.0.tgz",
+      "integrity": "sha512-ay19PRu0z+1W9tnmGyexIR/Sp0Rpt7H0mUCuEZQ5B+7O6Qf61+Co8TrR1SRIrKwD7Fu90jPy5y5MwFXy/vLwKg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@iota/bcs": "1.5.0",
+        "@iota/bcs": "1.6.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/base": "^1.2.4",

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -75,7 +75,7 @@
     "@iota/iota-interaction-ts": "^0.12.0"
   },
   "peerDependencies": {
-    "@iota/iota-sdk": "^1.11.0"
+    "@iota/iota-sdk": "^1.13.0"
   },
   "engines": {
     "node": ">=20"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -72,7 +72,7 @@
     "wasm-opt": "^1.4.0"
   },
   "dependencies": {
-    "@iota/iota-interaction-ts": "^0.12.0"
+    "@iota/iota-interaction-ts": "^0.13.0"
   },
   "peerDependencies": {
     "@iota/iota-sdk": "^1.13.0"

--- a/notarization-move/Move.history.json
+++ b/notarization-move/Move.history.json
@@ -1,18 +1,18 @@
 {
   "aliases": {
-    "mainnet": "6364aad5",
     "testnet": "2304aa97",
+    "mainnet": "6364aad5",
     "devnet": "daf90477"
   },
   "envs": {
+    "daf90477": [
+      "0x72c8433b88e6bdee0eb02a257fdebd0ec2b6c990043f35b155cb4c5cf727fdca"
+    ],
     "6364aad5": [
       "0x909ce9dcd9a5e97b7b8884fac8e018fad9dece348bf73837379b8694ff684cf3"
     ],
     "2304aa97": [
       "0x00412bd469b7f980227c6c574090348239852e43aa07818b315854fdd8a2d25f"
-    ],
-    "daf90477": [
-      "0x72c8433b88e6bdee0eb02a257fdebd0ec2b6c990043f35b155cb4c5cf727fdca"
     ]
   }
 }

--- a/notarization-move/Move.history.json
+++ b/notarization-move/Move.history.json
@@ -1,18 +1,18 @@
 {
   "aliases": {
-    "testnet": "2304aa97",
     "mainnet": "6364aad5",
+    "testnet": "2304aa97",
     "devnet": "daf90477"
   },
   "envs": {
-    "daf90477": [
-      "0x72c8433b88e6bdee0eb02a257fdebd0ec2b6c990043f35b155cb4c5cf727fdca"
-    ],
     "6364aad5": [
       "0x909ce9dcd9a5e97b7b8884fac8e018fad9dece348bf73837379b8694ff684cf3"
     ],
     "2304aa97": [
       "0x00412bd469b7f980227c6c574090348239852e43aa07818b315854fdd8a2d25f"
+    ],
+    "daf90477": [
+      "0x72c8433b88e6bdee0eb02a257fdebd0ec2b6c990043f35b155cb4c5cf727fdca"
     ]
   }
 }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] iota-sdk-types (`[https://github.com/iotaledger/iota-rust-sdk.git`](https://github.com/iotaledger/iota-rust-sdk.git%60)) update to rev = -
- [x] notarization_wasm: new peerDep. version for @iota/iota-sdk: "^1.13.0"
- [x] notarization_wasm: new dependency version for @iota/iota-interaction-ts: "^0.13.0"
- [x] pin all product-core.git dependencies to `tag = "v0.8.16"`
- [x] pin all iota.git dependencies to `rev = "96196f0da231883ec69cda04892c600ef6afa982"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67