### PR TITLE
Fix audit-trail Move security audit findings

### DIFF
--- a/audit-trail-move/Move.lock
+++ b/audit-trail-move/Move.lock
@@ -54,16 +54,16 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.22.1-rc"
+compiler-version = "1.20.1"
 edition = "2024.beta"
 flavor = "iota"
 
 [env]
 
 [env.localnet]
-chain-id = "c8ba4765"
-original-published-id = "0xf0a9009527072c34f56f34d8cf96218c3a2e008f30c568c55c08df01be19f51d"
-latest-published-id = "0xf0a9009527072c34f56f34d8cf96218c3a2e008f30c568c55c08df01be19f51d"
+chain-id = "4c9c65c9"
+original-published-id = "0x567c1e6c76db3b47826019f15818c747e0a2588d428e00c13863bcf683ec5bbe"
+latest-published-id = "0x567c1e6c76db3b47826019f15818c747e0a2588d428e00c13863bcf683ec5bbe"
 published-version = "1"
 
 [env.testnet]

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -313,6 +313,30 @@ fun remove_record<D: store + copy + drop>(
     });
 }
 
+/// Returns true if the record is within the last `count` records currently
+/// present in linked-table order.
+fun is_record_in_last_current_records<D: store + copy>(
+    records: &LinkedTable<u64, Record<D>>,
+    sequence_number: u64,
+    count: u64,
+): bool {
+    let mut remaining = count;
+    let mut current = *linked_table::back(records);
+
+    while (remaining > 0 && current.is_some()) {
+        let current_sequence_number = current.destroy_some();
+
+        if (current_sequence_number == sequence_number) {
+            return true
+        };
+
+        current = *linked_table::prev(records, current_sequence_number);
+        remaining = remaining - 1;
+    };
+
+    false
+}
+
 // ===== Record Operations =====
 
 /// Add a record to the trail
@@ -515,6 +539,9 @@ public fun delete_audit_trail<D: store + copy>(
 // ===== Locking =====
 
 /// Check if a record is locked based on the trail's locking configuration.
+///
+/// Count-based windows lock the last N records currently present in the trail,
+/// using the linked-table order after any deletions.
 /// Aborts with ERecordNotFound if the record doesn't exist.
 public fun is_record_locked<D: store + copy>(
     self: &AuditTrail<D>,
@@ -525,14 +552,22 @@ public fun is_record_locked<D: store + copy>(
 
     let record = linked_table::borrow(&self.records, sequence_number);
     let current_time = clock::timestamp_ms(clock);
+    let window = locking::delete_record_window(&self.locking_config);
 
-    locking::is_delete_record_locked(
-        &self.locking_config,
-        sequence_number,
-        record::added_at(record),
-        self.sequence_number,
-        current_time,
-    )
+    if (locking::is_time_locked(window, record::added_at(record), current_time)) {
+        return true
+    };
+
+    let count = locking::count_window(window);
+    if (count.is_some()) {
+        return is_record_in_last_current_records(
+            &self.records,
+            sequence_number,
+            count.destroy_some(),
+        )
+    };
+
+    false
 }
 
 /// Update the locking configuration. Requires `UpdateLockingConfig` permission.

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -26,6 +26,7 @@ use std::string::String;
 use tf_components::{capability::Capability, role_map::{Self, RoleMap}, timelock::TimeLock};
 
 // ===== Errors =====
+
 #[error]
 const ERecordNotFound: vector<u8> = b"Record not found at the given sequence number";
 #[error]
@@ -50,7 +51,9 @@ const ERecordTagAlreadyDefined: vector<u8> =
 #[error]
 const ERecordTagInUse: vector<u8> =
     b"The requested tag cannot be removed because it is already used by an existing record or role";
+
 // ===== Constants =====
+
 const INITIAL_ADMIN_ROLE_NAME: vector<u8> = b"Admin";
 
 // Package version, incremented when the package is updated
@@ -313,28 +316,75 @@ fun remove_record<D: store + copy + drop>(
     });
 }
 
-/// Returns true if the record is within the last `count` records currently
-/// present in linked-table order.
-fun is_record_in_last_current_records<D: store + copy>(
+/// Returns the lowest sequence_number within the last `count` records,
+/// given that sequence_numbers decrease monotonically, walking from
+/// the tail toward the head. Returns 0 if the table is empty or `count` is 0.
+fun get_lowest_sequence_number_in_count_window<D: store + copy>(
     records: &LinkedTable<u64, Record<D>>,
-    sequence_number: u64,
     count: u64,
-): bool {
-    let mut remaining = count;
+): u64 {
+    if (count == 0) {
+        return 0
+    };
+
     let mut current = *linked_table::back(records);
+    let mut remaining = count - 1;
+    let mut lowest = 0;
 
-    while (remaining > 0 && current.is_some()) {
+    while (current.is_some()) {
         let current_sequence_number = current.destroy_some();
+        lowest = current_sequence_number;
 
-        if (current_sequence_number == sequence_number) {
-            return true
+        if (remaining == 0) {
+            break
         };
 
         current = *linked_table::prev(records, current_sequence_number);
         remaining = remaining - 1;
     };
 
-    false
+    lowest
+}
+
+/// Precomputes the count-window threshold for `lock_window`.
+///
+/// Returns `Some(lowest_sequence_number_in_window)` when `lock_window` is a
+/// count-based window with a positive count, or `None` otherwise. A record
+/// with `sequence_number >= threshold` is count-locked.
+fun compute_count_lock_threshold<D: store + copy>(
+    records: &LinkedTable<u64, Record<D>>,
+    lock_window: &LockingWindow,
+): Option<u64> {
+    let count_opt = lock_window.count_window();
+    if (count_opt.is_some() && *count_opt.borrow() > 0) {
+        option::some(get_lowest_sequence_number_in_count_window(records, count_opt.destroy_some()))
+    } else {
+        option::none()
+    }
+}
+
+// Returns true if the record at `sequence_number` is locked by the
+// `lock_window`. Uses the precomputed `count_lock_threshold` to evaluate
+// count based windows and the `current_time` values to evaluate time
+// based windows.
+//
+// Aborts if `sequence_number` is not in `records`.
+fun is_record_locked_in_window<D: store + copy>(
+    records: &LinkedTable<u64, Record<D>>,
+    sequence_number: u64,
+    lock_window: &LockingWindow,
+    count_lock_threshold: &Option<u64>,
+    current_time: u64,
+): bool {
+    // This is the shared lock-evaluation core used by `is_record_locked` and
+    // `delete_records_batch`. Add new lock kinds here so both call sites pick
+    // them up automatically.
+    if (count_lock_threshold.is_some() && sequence_number >= *count_lock_threshold.borrow()) {
+        return true
+    };
+
+    let record = records.borrow(sequence_number);
+    lock_window.is_time_locked(record.added_at(), current_time)
 }
 
 // ===== Record Operations =====
@@ -437,8 +487,55 @@ public fun delete_record<D: store + copy + drop>(
 
 /// Delete up to `limit` records from the front of the trail.
 ///
-/// Requires `DeleteAllRecords` permission. Locked records are skipped.
-/// Returns the sequence numbers deleted in this batch, in deletion order.
+/// Requires `DeleteAllRecords` permission. Locked records and records whose
+/// tag is not permitted by `cap` are silently skipped. Returns the sequence
+/// numbers actually deleted, in deletion order. The returned vector may be
+/// shorter than `limit` (or empty) if records are skipped or the trail runs
+/// out of records before `limit` is reached.
+///
+/// Locking semantics
+/// -----------------
+/// The set of locked records is fixed at the start of the transaction:
+///
+/// * If a count-based `LockingWindow` is configured, the protected window is
+///   the last `count` records present *when this call begins*. Records that
+///   this same call deletes do not have an impact onto other records.
+///   The oldest protected record in the count-based `LockingWindow` is
+///   determined up front and its sequence_number is reused as delete criteria
+///   for every other candidate record. Concurrent transactions that add
+///   records or update the locking configuration are observed by *subsequent*
+///   transactions only.
+/// * Time-based locks are evaluated against the clock timestamp captured at
+///   the start of the call, so a record's lock status is also stable for the
+///   duration of the batch.
+///
+/// Equivalence with `delete_record`
+/// --------------------------------
+/// Running `delete_records_batch(limit)` produces the same final trail state as invoking
+/// `delete_record` once for every sequence number this batch would delete,
+/// as long as the locking configuration is not mutated and no new records are added
+/// to the trail between the batch calls.
+/// This holds because the count-window's lower bound is monotonic under deletion:
+/// in-window records are locked and therefore never deleted, so deleting any
+/// out-of-window record leaves the window's contents unchanged.
+///
+/// Caveats
+/// -------
+/// * **Partial progress.** The function always returns success even when
+///   fewer than `limit` records are deleted. Callers that need to detect
+///   "nothing left to delete" should inspect the length of the returned
+///   vector — an empty vector means every front-to-back candidate was either
+///   locked or tag-filtered out.
+/// * **Tag filtering is silent.** Records whose tag is not in `cap`'s allowed
+///   set are skipped without error. A capability with a narrow tag scope can
+///   therefore make the batch appear to "stop early" while locked-and-disallowed
+///   records still exist further back.
+/// * **Gas and object-size limits.** The call walks the trail from the front
+///   and deletes inline. Large `limit` values can exhaust the per-transaction
+///   gas budget or hit object-mutation limits. Prefer lower `limit` values
+///   resulting in modest batch sizes and repeat the call.
+/// * **Front-to-back order is fixed.** There is no way to target specific
+///   sequence numbers through this API — use `delete_record` for that.
 public fun delete_records_batch<D: store + copy + drop>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -461,13 +558,26 @@ public fun delete_records_batch<D: store + copy + drop>(
     let caller = ctx.sender();
     let timestamp = clock.timestamp_ms();
     let trail_id = self.id();
-    let mut current = *linked_table::front(&self.records);
+
+    let lock_window = *self.locking_config.delete_record_window();
+
+    // Precompute the count-window threshold once. Iteration deletes from the
+    // front while the back is preserved, so the threshold stays valid.
+    let count_lock_threshold = compute_count_lock_threshold(&self.records, &lock_window);
+
+    let mut current = *self.records.front();
 
     while (deleted < limit && current.is_some()) {
         let sequence_number = current.destroy_some();
-        current = *linked_table::next(&self.records, sequence_number);
+        current = *self.records.next(sequence_number);
 
-        if (self.is_record_locked(sequence_number, clock)) {
+        if (is_record_locked_in_window(
+            &self.records,
+            sequence_number,
+            &lock_window,
+            &count_lock_threshold,
+            timestamp,
+        )) {
             continue
         };
 
@@ -481,7 +591,7 @@ public fun delete_records_batch<D: store + copy + drop>(
             continue
         };
         self.remove_record(sequence_number, caller, timestamp, trail_id);
-        vector::push_back(&mut deleted_sequence_numbers, sequence_number);
+        deleted_sequence_numbers.push_back(sequence_number);
 
         deleted = deleted + 1;
     };
@@ -550,24 +660,17 @@ public fun is_record_locked<D: store + copy>(
 ): bool {
     assert!(linked_table::contains(&self.records, sequence_number), ERecordNotFound);
 
-    let record = linked_table::borrow(&self.records, sequence_number);
-    let current_time = clock::timestamp_ms(clock);
-    let window = locking::delete_record_window(&self.locking_config);
+    let current_time = clock.timestamp_ms();
+    let lock_window = self.locking_config.delete_record_window();
+    let count_lock_threshold = compute_count_lock_threshold(&self.records, lock_window);
 
-    if (locking::is_time_locked(window, record::added_at(record), current_time)) {
-        return true
-    };
-
-    let count = locking::count_window(window);
-    if (count.is_some()) {
-        return is_record_in_last_current_records(
-                &self.records,
-                sequence_number,
-                count.destroy_some(),
-            )
-    };
-
-    false
+    is_record_locked_in_window(
+        &self.records,
+        sequence_number,
+        lock_window,
+        &count_lock_threshold,
+        current_time,
+    )
 }
 
 /// Update the locking configuration. Requires `UpdateLockingConfig` permission.

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -571,13 +571,15 @@ public fun delete_records_batch<D: store + copy + drop>(
         let sequence_number = current.destroy_some();
         current = *self.records.next(sequence_number);
 
-        if (is_record_locked_in_window(
-            &self.records,
-            sequence_number,
-            &lock_window,
-            &count_lock_threshold,
-            timestamp,
-        )) {
+        if (
+            is_record_locked_in_window(
+                &self.records,
+                sequence_number,
+                &lock_window,
+                &count_lock_threshold,
+                timestamp,
+            )
+        ) {
             continue
         };
 

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -561,10 +561,10 @@ public fun is_record_locked<D: store + copy>(
     let count = locking::count_window(window);
     if (count.is_some()) {
         return is_record_in_last_current_records(
-            &self.records,
-            sequence_number,
-            count.destroy_some(),
-        )
+                &self.records,
+                sequence_number,
+                count.destroy_some(),
+            )
     };
 
     false

--- a/audit-trail-move/sources/locking.move
+++ b/audit-trail-move/sources/locking.move
@@ -12,10 +12,11 @@ use tf_components::timelock::{Self, TimeLock};
 /// UntilDestroyed cannot be used for trail deletion protection.
 const EUntilDestroyedNotSupportedForDeleteTrail: u64 = 0;
 
-/// Defines a locking window (time XOR count based, or none)
+/// Defines a delete-record locking window (time-based, count-based, or none).
 public enum LockingWindow has copy, drop, store {
     None,
     TimeBased { seconds: u64 },
+    /// Locks the last `count` records currently present in trail order.
     CountBased { count: u64 },
 }
 
@@ -41,7 +42,10 @@ public fun window_time_based(seconds: u64): LockingWindow {
     LockingWindow::TimeBased { seconds }
 }
 
-/// Create a count-based locking window
+/// Create a count-based locking window.
+///
+/// The trail locks the last `count` records currently present in linked-table
+/// order. Deletions can move older records into the protected window.
 public fun window_count_based(count: u64): LockingWindow {
     LockingWindow::CountBased { count }
 }
@@ -137,7 +141,11 @@ public(package) fun set_config(config: &mut LockingConfig, new_config: LockingCo
 
 /// Check if a record is locked based on time window.
 /// Returns true if the record was created within the time window.
-fun is_time_locked(window: &LockingWindow, record_timestamp: u64, current_time: u64): bool {
+public(package) fun is_time_locked(
+    window: &LockingWindow,
+    record_timestamp: u64,
+    current_time: u64,
+): bool {
     match (window) {
         LockingWindow::TimeBased { seconds } => {
             let time_window_ms = (*seconds) * 1000;
@@ -148,48 +156,7 @@ fun is_time_locked(window: &LockingWindow, record_timestamp: u64, current_time: 
     }
 }
 
-/// Check if a record is locked based on count window.
-/// Returns true if the record is among the last N records.
-fun is_count_locked(window: &LockingWindow, sequence_number: u64, total_records: u64): bool {
-    match (window) {
-        LockingWindow::CountBased { count } => {
-            let records_after = total_records - sequence_number - 1;
-            records_after < *count
-        },
-        _ => false,
-    }
-}
-
-/// Check if a record is locked by a window (either by time or count).
-fun is_window_locked(
-    window: &LockingWindow,
-    sequence_number: u64,
-    record_timestamp: u64,
-    total_records: u64,
-    current_time: u64,
-): bool {
-    is_time_locked(window, record_timestamp, current_time)
-        || is_count_locked(window, sequence_number, total_records)
-}
-
 // ===== Locking Logic (LockingConfig) =====
-
-/// Check if a record is locked for deletion.
-public fun is_delete_record_locked(
-    config: &LockingConfig,
-    sequence_number: u64,
-    record_timestamp: u64,
-    total_records: u64,
-    current_time: u64,
-): bool {
-    is_window_locked(
-        &config.delete_record_window,
-        sequence_number,
-        record_timestamp,
-        total_records,
-        current_time,
-    )
-}
 
 /// Check if trail deletion is currently locked.
 public fun is_delete_trail_locked(config: &LockingConfig, clock: &Clock): bool {

--- a/audit-trail-move/sources/locking.move
+++ b/audit-trail-move/sources/locking.move
@@ -12,6 +12,9 @@ use tf_components::timelock::{Self, TimeLock};
 /// UntilDestroyed cannot be used for trail deletion protection.
 const EUntilDestroyedNotSupportedForDeleteTrail: u64 = 0;
 
+/// A count-based locking window must protect at least one record.
+const ECountWindowMustBePositive: u64 = 1;
+
 /// Defines a delete-record locking window (time-based, count-based, or none).
 public enum LockingWindow has copy, drop, store {
     None,
@@ -45,8 +48,16 @@ public fun window_time_based(seconds: u64): LockingWindow {
 /// Create a count-based locking window.
 ///
 /// The trail locks the last `count` records currently present in linked-table
-/// order. Deletions can move older records into the protected window.
+/// order. To express "no deletion lock", use `window_none()` instead of
+/// passing `count == 0`.
+///
+/// Aborts
+/// ------
+/// * `ECountWindowMustBePositive` if `count == 0`. A zero-count window would
+///   protect no records and is functionally identical to `window_none()`;
+///   rejecting it at construction prevents silently misconfigured trails.
 public fun window_count_based(count: u64): LockingWindow {
+    assert!(count > 0, ECountWindowMustBePositive);
     LockingWindow::CountBased { count }
 }
 

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -94,6 +94,7 @@ public fun admin_permissions(): VecSet<Permission> {
     perms.insert(add_roles());
     perms.insert(update_roles());
     perms.insert(delete_roles());
+    perms.insert(migrate_audit_trail());
     perms
 }
 

--- a/audit-trail-move/tests/capability_tests.move
+++ b/audit-trail-move/tests/capability_tests.move
@@ -66,7 +66,7 @@ fun setup_trail_with_record_admin_role(scenario: &mut Scenario, admin_user: addr
     // Setup: Create audit trail with admin capability
     let trail_id = {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -118,7 +118,7 @@ fun test_new_capability() {
 
     let trail_id = {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -603,7 +603,7 @@ fun test_revoked_capability_cannot_be_used() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -694,7 +694,7 @@ fun test_new_capability_for_nonexistent_role() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -736,7 +736,7 @@ fun test_revoke_capability_permission_denied() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -834,7 +834,7 @@ fun test_new_capability_permission_denied() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );

--- a/audit-trail-move/tests/create_audit_trail_tests.move
+++ b/audit-trail-move/tests/create_audit_trail_tests.move
@@ -26,7 +26,7 @@ fun test_create_without_initial_record() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -68,7 +68,7 @@ fun test_tag_admin_role_can_manage_available_record_tags() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -296,7 +296,7 @@ fun test_create_minimal_metadata() {
         clock.set_for_testing(3000);
 
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -379,7 +379,7 @@ fun test_create_multiple_trails() {
     // Create first trail
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -398,7 +398,7 @@ fun test_create_multiple_trails() {
     // Create second trail
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -428,7 +428,7 @@ fun test_create_metadata_admin_role() {
     // Creator creates the audit trail
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );

--- a/audit-trail-move/tests/locking_tests.move
+++ b/audit-trail-move/tests/locking_tests.move
@@ -863,6 +863,89 @@ fun test_count_based_locking_old_record_can_delete() {
 }
 
 #[test]
+fun test_count_based_locking_uses_current_records_after_tail_deletion() {
+    let admin = @0xAD;
+    let mut scenario = ts::begin(admin);
+
+    {
+        let locking_config = locking::new(
+            locking::window_none(),
+            timelock::none(),
+            timelock::none(),
+        );
+        let (admin_cap, _) = setup_test_audit_trail(
+            &mut scenario,
+            locking_config,
+            std::option::none(),
+        );
+        transfer::public_transfer(admin_cap, admin);
+    };
+
+    ts::next_tx(&mut scenario, admin);
+    {
+        let (admin_cap, mut trail, mut clock) = fetch_capability_trail_and_clock(&mut scenario);
+        let record_lock_admin_role = string::utf8(b"RecordLockAdmin");
+        let record_lock_admin_perms = permission::from_vec(vector[
+            permission::add_record(),
+            permission::delete_record(),
+            permission::update_locking_config_for_delete_record(),
+        ]);
+
+        trail
+            .access_mut()
+            .create_role(
+                &admin_cap,
+                record_lock_admin_role,
+                record_lock_admin_perms,
+                std::option::none(),
+                &clock,
+                ts::ctx(&mut scenario),
+            );
+
+        let record_lock_admin_cap = test_utils::new_capability_without_restrictions(
+            trail.access_mut(),
+            &admin_cap,
+            &string::utf8(b"RecordLockAdmin"),
+            &clock,
+            ts::ctx(&mut scenario),
+        );
+
+        clock.set_for_testing(initial_time_for_testing() + 1000);
+
+        let mut i = 0u64;
+        while (i < 5) {
+            trail.add_record(
+                &record_lock_admin_cap,
+                record::new_text(string::utf8(b"Record")),
+                std::option::none(),
+                std::option::none(),
+                &clock,
+                ts::ctx(&mut scenario),
+            );
+            i = i + 1;
+        };
+
+        trail.delete_record(&record_lock_admin_cap, 4, &clock, ts::ctx(&mut scenario));
+        trail.update_delete_record_window(
+            &record_lock_admin_cap,
+            locking::window_count_based(2),
+            &clock,
+            ts::ctx(&mut scenario),
+        );
+
+        assert!(!trail.has_record(4), 0);
+        assert!(!trail.is_record_locked(1, &clock), 1);
+        assert!(trail.is_record_locked(2, &clock), 2);
+        assert!(trail.is_record_locked(3, &clock), 3);
+
+        record_lock_admin_cap.destroy_for_testing();
+        cleanup_capability_trail_and_clock(&scenario, admin_cap, trail, clock);
+    };
+
+    ts::end(scenario);
+}
+
+#[test]
 fun test_time_based_locking_still_locked_before_expiry() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);

--- a/audit-trail-move/tests/metadata_tests.move
+++ b/audit-trail-move/tests/metadata_tests.move
@@ -28,7 +28,7 @@ fun test_update_metadata_success() {
     // Setup: Create audit trail
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -151,7 +151,7 @@ fun test_update_metadata_permission_denied() {
     // Setup
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -223,7 +223,7 @@ fun test_update_metadata_revoked_capability() {
     // Setup: Create audit trail
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );

--- a/audit-trail-move/tests/permission_tests.move
+++ b/audit-trail-move/tests/permission_tests.move
@@ -117,6 +117,13 @@ fun test_admin_permissions_include_tag_management() {
 }
 
 #[test]
+fun test_admin_permissions_include_migration() {
+    let perms = permission::admin_permissions();
+
+    assert!(permission::has_permission(&perms, &permission::migrate_audit_trail()), 0);
+}
+
+#[test]
 #[expected_failure(abort_code = vec_set::EKeyAlreadyExists)]
 fun test_from_vec_duplicate_permission() {
     // VecSet should throw error EKeyAlreadyExists on duplicate insertions

--- a/audit-trail-move/tests/role_tests.move
+++ b/audit-trail-move/tests/role_tests.move
@@ -32,7 +32,7 @@ fun test_role_based_permission_delegation() {
     // Step 1: admin_user creates the audit trail
     let trail_id = {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -227,7 +227,7 @@ fun test_create_role_rejects_undefined_record_tags() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -268,7 +268,7 @@ fun test_delete_role_success() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -332,7 +332,7 @@ fun test_remove_record_tag_rejects_role_only_usage() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -385,7 +385,7 @@ fun test_create_role_permission_denied() {
     // Setup
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -463,7 +463,7 @@ fun test_delete_role_permission_denied() {
     // Setup
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -545,7 +545,7 @@ fun test_update_role_permissions_permission_denied() {
     // Setup
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -634,7 +634,7 @@ fun test_get_role_permissions_nonexistent() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -667,7 +667,7 @@ fun test_update_role_permissions_success() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -733,7 +733,7 @@ fun test_update_role_permissions_rejects_undefined_record_tags() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );
@@ -783,7 +783,7 @@ fun test_update_role_permissions_nonexistent() {
 
     {
         let locking_config = locking::new(
-            locking::window_count_based(0),
+            locking::window_none(),
             timelock::none(),
             timelock::none(),
         );

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -175,6 +175,8 @@ controls three independent behaviors:
 
 An audit trail can be deleted only after its records are removed and the delete-trail lock allows deletion. Records can
 be deleted individually with `TrailRecords::delete()` or in batches with `TrailRecords::delete_records_batch()`.
+For count-based delete windows, the Move package protects the last N records currently present in trail order. Deletions
+can move older records into that protected window, and large count values increase delete gas linearly.
 
 #### Updating Locking Rules
 
@@ -232,7 +234,8 @@ The trail deletion process does not remove records automatically. The trail must
   tag.
 - `Role Tags`: Optional role-scoped tag restrictions. They narrow which tagged records a role may operate on.
 - `Locking Config`: The active locking rules for record deletion, trail deletion, and record writes.
-- `Delete Record Window`: A locking rule that controls when individual records can be deleted.
+- `Delete Record Window`: A locking rule that controls when individual records can be deleted. Count-based windows protect
+  the last N records currently present in trail order.
 - `Delete Trail Lock`: A time lock that controls when the entire trail can be deleted.
 - `Write Lock`: A time lock that controls when new records can be added.
 - `Immutable Metadata`: Optional metadata stored at creation time and never updated after the trail is created.

--- a/audit-trail-rs/src/client/full_client.rs
+++ b/audit-trail-rs/src/client/full_client.rs
@@ -22,7 +22,7 @@
 //! let created = client
 //!     .create_trail()
 //!     .with_initial_record_parts(Data::text("Initial record"), None, None)
-//!     .finish()
+//!     .finish()?
 //!     .with_gas_budget(1_000_000)
 //!     .build_and_execute(client)
 //!     .await?;
@@ -53,7 +53,7 @@
 //!     .create_trail()
 //!     .with_initial_record_parts(Data::text("Initial record"), None, None)
 //!     .with_record_tags(["finance"])
-//!     .finish()
+//!     .finish()?
 //!     .build_and_execute(client)
 //!     .await?;
 //!

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -8,8 +8,9 @@ use std::collections::HashSet;
 use iota_interaction::types::base_types::IotaAddress;
 use product_common::transaction::transaction_builder::TransactionBuilder;
 
-use super::types::{Data, ImmutableMetadata, InitialRecord, LockingConfig};
+use super::types::{Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, TimeLock};
 use crate::core::create::CreateTrail;
+use crate::error::Error;
 
 /// Builder for creating an audit trail.
 ///
@@ -104,7 +105,17 @@ impl AuditTrailBuilder {
     }
 
     /// Finalizes the builder and creates the trail-creation transaction builder.
-    pub fn finish(self) -> TransactionBuilder<CreateTrail> {
-        TransactionBuilder::new(CreateTrail::new(self))
+    ///
+    /// Validates the configured [`LockingConfig`] before returning the transaction. Currently this rejects:
+    /// - [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`] used as `delete_trail_lock` (mirrors the Move
+    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidArgument`] when the locking configuration is invalid.
+    pub fn finish(self) -> Result<TransactionBuilder<CreateTrail>, Error> {
+        self.locking_config.validate()?;
+        Ok(TransactionBuilder::new(CreateTrail::new(self)))
     }
 }

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use iota_interaction::types::base_types::IotaAddress;
 use product_common::transaction::transaction_builder::TransactionBuilder;
 
-use super::types::{Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, TimeLock};
+use super::types::{Data, ImmutableMetadata, InitialRecord, LockingConfig};
 use crate::core::create::CreateTrail;
 use crate::error::Error;
 

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -49,52 +49,79 @@ impl<'a, C> TrailLocking<'a, C> {
     /// Replaces the full locking configuration for the trail.
     ///
     /// This overwrites all three locking dimensions at once: record delete window, trail delete lock, and
-    /// write lock.
-    pub fn update<S>(&self, config: LockingConfig) -> TransactionBuilder<UpdateLockingConfig>
+    /// write lock. The supplied [`LockingConfig`] is validated before the transaction is constructed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidArgument`] when `config` contains:
+    /// * `delete_record_window` using [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
+    /// * `delete_trail_lock` using [`TimeLock::UntilDestroyed`] (mirrors the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort).
+    pub fn update<S>(&self, config: LockingConfig) -> Result<TransactionBuilder<UpdateLockingConfig>, Error>
     where
         C: AuditTrailFull + CoreClient<S>,
         S: Signer<IotaKeySignature> + OptionalSync,
     {
+        config.validate()?;
         let owner = self.client.sender_address();
-        TransactionBuilder::new(UpdateLockingConfig::new(
+        Ok(TransactionBuilder::new(UpdateLockingConfig::new(
             self.trail_id,
             owner,
             config,
             self.selected_capability_id,
-        ))
+        )))
     }
 
     /// Updates only the delete-record window.
     ///
-    /// Count-based windows protect the last N records currently present in trail
-    /// order. Large count values increase delete gas linearly.
-    pub fn update_delete_record_window<S>(&self, window: LockingWindow) -> TransactionBuilder<UpdateDeleteRecordWindow>
+    /// Count-based windows protect the last N records present in trail order at the start of each call that
+    /// consults the window. `count` must be positive; pass [`LockingWindow::None`] to remove the lock.
+    /// Large count values increase delete gas linearly because the on-chain check walks backward from the tail
+    /// to determine the protected window's lower bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidArgument`] when `window` is [`LockingWindow::CountBased`] with `count == 0`
+    /// (mirrors the Move `ECountWindowMustBePositive` abort).
+    pub fn update_delete_record_window<S>(
+        &self,
+        window: LockingWindow,
+    ) -> Result<TransactionBuilder<UpdateDeleteRecordWindow>, Error>
     where
         C: AuditTrailFull + CoreClient<S>,
         S: Signer<IotaKeySignature> + OptionalSync,
     {
+        window.validate()?;
         let owner = self.client.sender_address();
-        TransactionBuilder::new(UpdateDeleteRecordWindow::new(
+        Ok(TransactionBuilder::new(UpdateDeleteRecordWindow::new(
             self.trail_id,
             owner,
             window,
             self.selected_capability_id,
-        ))
+        )))
     }
 
     /// Updates only the delete-trail time lock.
-    pub fn update_delete_trail_lock<S>(&self, lock: TimeLock) -> TransactionBuilder<UpdateDeleteTrailLock>
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidArgument`] when `lock` is [`TimeLock::UntilDestroyed`]
+    /// (mirrors the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort).
+    pub fn update_delete_trail_lock<S>(
+        &self,
+        lock: TimeLock,
+    ) -> Result<TransactionBuilder<UpdateDeleteTrailLock>, Error>
     where
         C: AuditTrailFull + CoreClient<S>,
         S: Signer<IotaKeySignature> + OptionalSync,
     {
+        lock.validate_as_delete_trail_lock()?;
         let owner = self.client.sender_address();
-        TransactionBuilder::new(UpdateDeleteTrailLock::new(
+        Ok(TransactionBuilder::new(UpdateDeleteTrailLock::new(
             self.trail_id,
             owner,
             lock,
             self.selected_capability_id,
-        ))
+        )))
     }
 
     /// Updates only the write lock.
@@ -114,8 +141,9 @@ impl<'a, C> TrailLocking<'a, C> {
 
     /// Returns `true` when the given record is currently locked against deletion.
     ///
-    /// For count-based windows, the check uses the current on-chain record order
-    /// after deletions.
+    /// For count-based windows, the check determines the protected window's lower bound by walking back
+    /// from the current tail at call time; time-based locks are evaluated against the clock timestamp at
+    /// call time. The result reflects the trail snapshot observed by this read-only call.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -65,6 +65,9 @@ impl<'a, C> TrailLocking<'a, C> {
     }
 
     /// Updates only the delete-record window.
+    ///
+    /// Count-based windows protect the last N records currently present in trail
+    /// order. Large count values increase delete gas linearly.
     pub fn update_delete_record_window<S>(&self, window: LockingWindow) -> TransactionBuilder<UpdateDeleteRecordWindow>
     where
         C: AuditTrailFull + CoreClient<S>,
@@ -110,6 +113,9 @@ impl<'a, C> TrailLocking<'a, C> {
     }
 
     /// Returns `true` when the given record is currently locked against deletion.
+    ///
+    /// For count-based windows, the check uses the current on-chain record order
+    /// after deletions.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -54,8 +54,10 @@ impl<'a, C> TrailLocking<'a, C> {
     /// # Errors
     ///
     /// Returns [`Error::InvalidArgument`] when `config` contains:
-    /// * `delete_record_window` using [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
-    /// * `delete_trail_lock` using [`TimeLock::UntilDestroyed`] (mirrors the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort).
+    /// * `delete_record_window` using [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move
+    ///   `ECountWindowMustBePositive` abort).
+    /// * `delete_trail_lock` using [`TimeLock::UntilDestroyed`] (mirrors the Move
+    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort).
     pub fn update<S>(&self, config: LockingConfig) -> Result<TransactionBuilder<UpdateLockingConfig>, Error>
     where
         C: AuditTrailFull + CoreClient<S>,

--- a/audit-trail-rs/src/core/records/mod.rs
+++ b/audit-trail-rs/src/core/records/mod.rs
@@ -128,12 +128,12 @@ impl<'a, C, D> TrailRecords<'a, C, D> {
     ///
     /// # Caveats
     ///
-    /// - **Partial progress is not an error.** An empty returned vector means every front-to-back candidate was
-    ///   either locked or tag-filtered out.
-    /// - **Tag filtering is silent.** A capability with a narrow tag scope can make the batch appear to stop
-    ///   early while locked-and-disallowed records still exist further back.
-    /// - **Gas and object-size limits.** The call walks and mutates inline; prefer modest `limit` values and
-    ///   repeat the call rather than passing a single large `limit`.
+    /// - **Partial progress is not an error.** An empty returned vector means every front-to-back candidate was either
+    ///   locked or tag-filtered out.
+    /// - **Tag filtering is silent.** A capability with a narrow tag scope can make the batch appear to stop early
+    ///   while locked-and-disallowed records still exist further back.
+    /// - **Gas and object-size limits.** The call walks and mutates inline; prefer modest `limit` values and repeat the
+    ///   call rather than passing a single large `limit`.
     /// - **Order is fixed.** Use [`Self::delete`] to target specific sequence numbers.
     pub fn delete_records_batch<S>(&self, limit: u64) -> TransactionBuilder<DeleteRecordsBatch>
     where

--- a/audit-trail-rs/src/core/records/mod.rs
+++ b/audit-trail-rs/src/core/records/mod.rs
@@ -112,8 +112,29 @@ impl<'a, C, D> TrailRecords<'a, C, D> {
 
     /// Builds a transaction that deletes up to `limit` records in one operation.
     ///
-    /// Batch deletion requires `DeleteAllRecords`, skips locked records and records outside the capability's tag
-    /// access, and removes up to `limit` eligible records in trail order.
+    /// Batch deletion requires `DeleteAllRecords`, walks the trail from the front in sequence order, and silently
+    /// skips records that are either locked or whose tag is not in the capability's allowed set. The returned
+    /// vector contains the sequence numbers actually deleted in deletion order; it may be shorter than `limit`
+    /// (or empty) when records are skipped or the trail runs out of records before `limit` is reached.
+    ///
+    /// # Locking semantics
+    ///
+    /// The set of locked records is fixed at the start of the transaction. For count-based windows, the protected
+    /// window is the last `count` records present when the call begins — records this same call deletes do not
+    /// change which other records are protected. Time-based locks are evaluated against the clock timestamp
+    /// captured at the start of the call. Running `delete_records_batch(limit)` therefore produces the same
+    /// final trail state as invoking `delete_record` once per deletable sequence number, as long as the locking
+    /// configuration is not mutated and no new records are added between calls.
+    ///
+    /// # Caveats
+    ///
+    /// - **Partial progress is not an error.** An empty returned vector means every front-to-back candidate was
+    ///   either locked or tag-filtered out.
+    /// - **Tag filtering is silent.** A capability with a narrow tag scope can make the batch appear to stop
+    ///   early while locked-and-disallowed records still exist further back.
+    /// - **Gas and object-size limits.** The call walks and mutates inline; prefer modest `limit` values and
+    ///   repeat the call rather than passing a single large `limit`.
+    /// - **Order is fixed.** Use [`Self::delete`] to target specific sequence numbers.
     pub fn delete_records_batch<S>(&self, limit: u64) -> TransactionBuilder<DeleteRecordsBatch>
     where
         C: AuditTrailFull + CoreClient<S>,

--- a/audit-trail-rs/src/core/records/transactions.rs
+++ b/audit-trail-rs/src/core/records/transactions.rs
@@ -213,9 +213,12 @@ impl Transaction for DeleteRecord {
 
 /// Transaction that deletes multiple records in a batch operation.
 ///
-/// The Move entry point skips locked records, deletes up to `limit` unlocked records in trail order, and returns
-/// the deleted sequence numbers. The Rust implementation mirrors that output by collecting the matching
-/// `RecordDeleted` events in order.
+/// The Move entry point walks the trail from the front, silently skips records that are locked or whose tag is
+/// not permitted by the capability, and deletes up to `limit` eligible records. Lock state — both count-based
+/// and time-based — is evaluated against the trail snapshot and clock timestamp captured at the start of the
+/// call, so the deletable set is stable for the batch's duration. The Rust implementation mirrors the Move
+/// output by collecting the matching `RecordDeleted` events in deletion order; the returned vector may be
+/// shorter than `limit` (or empty) and that is not an error.
 #[derive(Debug, Clone)]
 pub struct DeleteRecordsBatch {
     /// Trail object ID containing the records.

--- a/audit-trail-rs/src/core/types/locking.rs
+++ b/audit-trail-rs/src/core/types/locking.rs
@@ -115,7 +115,7 @@ impl TimeLock {
     }
 }
 
-/// Defines a locking window (none, time based, or count based).
+/// Defines a delete-record locking window.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum LockingWindow {
     /// No delete window is enforced.
@@ -126,9 +126,13 @@ pub enum LockingWindow {
         /// Window size in seconds.
         seconds: u64,
     },
-    /// Records may be deleted only within the first `count` subsequent records.
+    /// Locks the last `count` records currently present in trail order.
+    ///
+    /// Deletions can move older records into this protected window. The on-chain
+    /// check walks backward from the current tail, so delete gas scales linearly
+    /// with `count`.
     CountBased {
-        /// Number of subsequent records after which deletion is no longer allowed.
+        /// Number of current tail records protected from deletion.
         count: u64,
     },
 }

--- a/audit-trail-rs/src/core/types/locking.rs
+++ b/audit-trail-rs/src/core/types/locking.rs
@@ -22,6 +22,21 @@ pub struct LockingConfig {
 }
 
 impl LockingConfig {
+    /// Validates the locking configuration without contacting the chain.
+    ///
+    /// Currently this rejects:
+    /// - [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`] used as `delete_trail_lock` (mirrors the Move
+    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    ///
+    /// Public entry points that accept a `LockingConfig` call this so that misconfiguration is reported
+    /// before any transaction is built.
+    pub fn validate(&self) -> Result<(), Error> {
+        self.delete_record_window.validate()?;
+        self.delete_trail_lock.validate_as_delete_trail_lock()?;
+        Ok(())
+    }
+
     /// Creates a new `Argument` from the `LockingConfig`.
     ///
     /// To be used when creating or updating locking config on the ledger.
@@ -64,6 +79,20 @@ pub enum TimeLock {
 }
 
 impl TimeLock {
+    /// Validates this lock as a candidate for the trail-level delete lock.
+    ///
+    /// Rejects [`TimeLock::UntilDestroyed`] (mirrors the Move
+    /// `EUntilDestroyedNotSupportedForDeleteTrail` abort). All other variants are accepted; time-based
+    /// timestamp validity is enforced on-chain because it depends on the clock at execution time.
+    pub fn validate_as_delete_trail_lock(&self) -> Result<(), Error> {
+        if matches!(self, Self::UntilDestroyed) {
+            return Err(Error::InvalidArgument(
+                "TimeLock::UntilDestroyed is not supported as a delete-trail lock".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
         match self {
             Self::None => Ok(ptb.programmable_move_call(
@@ -128,20 +157,41 @@ pub enum LockingWindow {
     },
     /// Locks the last `count` records currently present in trail order.
     ///
-    /// Deletions can move older records into this protected window. The on-chain
-    /// check walks backward from the current tail, so delete gas scales linearly
-    /// with `count`.
+    /// The protected window is evaluated against the records present when the
+    /// transaction begins; concurrent additions are observed by subsequent
+    /// transactions only. `count` must be positive — use [`LockingWindow::None`]
+    /// to express "no deletion lock". Constructing this variant with `count == 0`
+    /// is rejected client-side with [`Error::InvalidArgument`] and would otherwise
+    /// abort on-chain with `ECountWindowMustBePositive`.
+    ///
+    /// The on-chain check walks backward from the current tail once per call,
+    /// so delete gas scales linearly with `count`.
     CountBased {
-        /// Number of current tail records protected from deletion.
+        /// Number of current tail records protected from deletion. Must be `> 0`.
         count: u64,
     },
 }
 
 impl LockingWindow {
+    /// Validates the window configuration without contacting the chain.
+    ///
+    /// Rejects [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move
+    /// `ECountWindowMustBePositive` abort). All other variants are always valid.
+    pub fn validate(&self) -> Result<(), Error> {
+        if let Self::CountBased { count: 0 } = self {
+            return Err(Error::InvalidArgument(
+                "LockingWindow::CountBased requires count > 0; use LockingWindow::None for no deletion lock"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Creates a new `Argument` from the `LockingWindow`.
     ///
     /// To be used when creating or updating locking config on the ledger.
     pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+        self.validate()?;
         match self {
             Self::None => Ok(ptb.programmable_move_call(
                 package_id,

--- a/audit-trail-rs/tests/e2e/client.rs
+++ b/audit-trail-rs/tests/e2e/client.rs
@@ -219,7 +219,7 @@ impl TestClient {
             .create_trail()
             .with_initial_record(InitialRecord::new(data, None, None))
             .with_record_tags(tags)
-            .finish()
+            .finish()?
             .build_and_execute(self)
             .await?
             .output;

--- a/audit-trail-rs/tests/e2e/locking.rs
+++ b/audit-trail-rs/tests/e2e/locking.rs
@@ -39,7 +39,7 @@ async fn update_locking_config_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update(config_with_window(LockingWindow::CountBased { count: 2 }))
+        .update(config_with_window(LockingWindow::CountBased { count: 2 }))?
         .build_and_execute(&client)
         .await?;
 
@@ -63,7 +63,7 @@ async fn update_locking_config_switches_count_to_time_based() -> anyhow::Result<
             None,
         ))
         .with_locking_config(config_with_window(LockingWindow::CountBased { count: 3 }))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output
@@ -80,7 +80,7 @@ async fn update_locking_config_switches_count_to_time_based() -> anyhow::Result<
 
     trail
         .locking()
-        .update(config_with_window(LockingWindow::TimeBased { seconds: 300 }))
+        .update(config_with_window(LockingWindow::TimeBased { seconds: 300 }))?
         .build_and_execute(&client)
         .await?;
 
@@ -111,7 +111,7 @@ async fn update_delete_record_window_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::TimeBased { seconds: 120 })
+        .update_delete_record_window(LockingWindow::TimeBased { seconds: 120 })?
         .build_and_execute(&client)
         .await?;
 
@@ -142,7 +142,7 @@ async fn update_delete_trail_lock_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update_delete_trail_lock(TimeLock::Infinite)
+        .update_delete_trail_lock(TimeLock::Infinite)?
         .build_and_execute(&client)
         .await?;
 
@@ -211,7 +211,7 @@ async fn update_locking_config_requires_permission() -> anyhow::Result<()> {
     let result = client
         .trail(trail_id)
         .locking()
-        .update(config_with_window(LockingWindow::TimeBased { seconds: 60 }))
+        .update(config_with_window(LockingWindow::TimeBased { seconds: 60 }))?
         .build_and_execute(&client)
         .await;
 
@@ -252,7 +252,7 @@ async fn is_record_locked_supports_count_window_and_missing_sequence() -> anyhow
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-locking-status-e2e"), None, None))
         .with_locking_config(config_with_window(LockingWindow::CountBased { count: 2 }))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output
@@ -305,7 +305,7 @@ async fn delete_window_variants_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::TimeBased { seconds: 3600 })
+        .update_delete_record_window(LockingWindow::TimeBased { seconds: 3600 })?
         .build_and_execute(&client)
         .await?;
 
@@ -317,7 +317,7 @@ async fn delete_window_variants_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::CountBased { count: 1 })
+        .update_delete_record_window(LockingWindow::CountBased { count: 1 })?
         .build_and_execute(&client)
         .await?;
 
@@ -329,7 +329,7 @@ async fn delete_window_variants_roundtrip() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::None)
+        .update_delete_record_window(LockingWindow::None)?
         .build_and_execute(&client)
         .await?;
 
@@ -367,7 +367,7 @@ async fn updated_time_lock_blocks_record_deletion() -> anyhow::Result<()> {
 
     trail
         .locking()
-        .update(config_with_window(LockingWindow::TimeBased { seconds: 3600 }))
+        .update(config_with_window(LockingWindow::TimeBased { seconds: 3600 }))?
         .build_and_execute(&client)
         .await?;
 
@@ -399,7 +399,7 @@ async fn updated_delete_window_can_block_and_then_allow_deletion() -> anyhow::Re
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::CountBased { count: 1 })
+        .update_delete_record_window(LockingWindow::CountBased { count: 1 })?
         .build_and_execute(&client)
         .await?;
 
@@ -411,7 +411,7 @@ async fn updated_delete_window_can_block_and_then_allow_deletion() -> anyhow::Re
 
     trail
         .locking()
-        .update_delete_record_window(LockingWindow::None)
+        .update_delete_record_window(LockingWindow::None)?
         .build_and_execute(&client)
         .await?;
 

--- a/audit-trail-rs/tests/e2e/records.rs
+++ b/audit-trail-rs/tests/e2e/records.rs
@@ -879,7 +879,7 @@ async fn delete_record_fails_while_time_locked() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("locked"), None, None))
         .with_locking_config(config_with_window(LockingWindow::TimeBased { seconds: 3600 }))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -942,7 +942,7 @@ async fn delete_record_fails_while_count_locked() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("count-locked"), None, None))
         .with_locking_config(config_with_window(LockingWindow::CountBased { count: 5 }))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -965,7 +965,7 @@ async fn delete_records_batch_respects_limit_and_deletes_oldest_first() -> anyho
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("batch-initial"), None, None))
         .with_locking_config(config_with_window(LockingWindow::None))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -1034,7 +1034,7 @@ async fn delete_records_batch_skips_locked_records() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("batch-skip-locked-initial"), None, None))
         .with_locking_config(config_with_window(LockingWindow::CountBased { count: 1 }))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;

--- a/audit-trail-rs/tests/e2e/trail.rs
+++ b/audit-trail-rs/tests/e2e/trail.rs
@@ -25,7 +25,7 @@ async fn create_trail_with_default_builder_settings() -> anyhow::Result<()> {
     let created = client
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("audit-trail-create-default"), None, None))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -47,7 +47,7 @@ async fn create_trail_with_default_builder_settings() -> anyhow::Result<()> {
 async fn create_empty_trail_with_default_builder_settings() -> anyhow::Result<()> {
     let client = get_funded_test_client().await?;
 
-    let created = client.create_trail().finish().build_and_execute(&client).await?.output;
+    let created = client.create_trail().finish()?.build_and_execute(&client).await?.output;
 
     assert_eq!(created.creator, client.sender_address());
 
@@ -80,7 +80,7 @@ async fn create_trail_with_metadata_and_time_lock() -> anyhow::Result<()> {
         .with_locking_config(config_with_window(LockingWindow::TimeBased { seconds: 300 }))
         .with_trail_metadata(immutable_metadata.clone())
         .with_updatable_metadata("updatable metadata")
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -109,7 +109,7 @@ async fn create_trail_with_bytes_and_count_lock() -> anyhow::Result<()> {
         ))
         .with_locking_config(config_with_window(LockingWindow::CountBased { count: 3 }))
         .with_trail_metadata_parts("Trail Count Lock", Some("count lock description".to_string()))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -133,7 +133,7 @@ async fn create_trail_with_custom_admin_address() -> anyhow::Result<()> {
         .create_trail()
         .with_admin(custom_admin)
         .with_initial_record(InitialRecord::new(Data::text("audit-trail-custom-admin"), None, None))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -157,7 +157,7 @@ async fn get_returns_on_chain_trail() -> anyhow::Result<()> {
         .with_initial_record(InitialRecord::new(Data::text("trail-get-e2e"), None, None))
         .with_trail_metadata_parts("Get Test", Some("description".into()))
         .with_updatable_metadata("initial updatable")
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -187,7 +187,7 @@ async fn get_trail_without_metadata() -> anyhow::Result<()> {
     let created = client
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-no-meta-e2e"), None, None))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -320,7 +320,7 @@ async fn update_metadata_does_not_affect_immutable_metadata() -> anyhow::Result<
         .with_initial_record(InitialRecord::new(Data::text("trail-immutable-check-e2e"), None, None))
         .with_trail_metadata(immutable.clone())
         .with_updatable_metadata("mutable")
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -451,7 +451,7 @@ async fn delete_records_batch_then_delete_audit_trail_roundtrip() -> anyhow::Res
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-batch-delete-e2e"), None, None))
         .with_locking_config(config_with_window(LockingWindow::None))
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -503,7 +503,7 @@ async fn manage_record_tag_registry_roundtrip() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-tag-registry"), None, None))
         .with_record_tags(["finance"])
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -534,7 +534,7 @@ async fn remove_record_tag_rejects_in_use_tag() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-tag-in-use"), None, None))
         .with_record_tags(["finance"])
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;
@@ -571,7 +571,7 @@ async fn remove_record_tag_rejects_role_only_usage() -> anyhow::Result<()> {
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("trail-tag-role-usage"), None, None))
         .with_record_tags(["finance"])
-        .finish()
+        .finish()?
         .build_and_execute(&client)
         .await?
         .output;

--- a/bindings/wasm/audit_trail_wasm/src/builder.rs
+++ b/bindings/wasm/audit_trail_wasm/src/builder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use audit_trail::core::builder::AuditTrailBuilder;
-use iota_interaction_ts::wasm_error::Result;
+use iota_interaction_ts::wasm_error::{Result, WasmResult};
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_iota_address};
 use product_common::bindings::WasmIotaAddress;
@@ -66,8 +66,11 @@ impl WasmAuditTrailBuilder {
     }
 
     /// Finalizes the builder into a transaction wrapper.
+    ///
+    /// Throws when the configured `LockingConfig` is invalid (e.g. `CountBased` window with `count == 0`).
     #[wasm_bindgen(unchecked_return_type = "TransactionBuilder<CreateTrail>")]
     pub fn finish(self) -> Result<WasmTransactionBuilder> {
-        Ok(into_transaction_builder(WasmCreateTrail::new(self)))
+        let tx = self.0.finish().wasm_result()?.into_inner();
+        Ok(into_transaction_builder(WasmCreateTrail(tx)))
     }
 }

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
@@ -47,6 +47,7 @@ impl WasmTrailLocking {
             .trail(self.trail_id)
             .locking()
             .update(config.into())
+            .wasm_result()?
             .into_inner();
         Ok(into_transaction_builder(WasmUpdateLockingConfig(tx)))
     }
@@ -59,6 +60,7 @@ impl WasmTrailLocking {
             .trail(self.trail_id)
             .locking()
             .update_delete_record_window(window.into())
+            .wasm_result()?
             .into_inner();
         Ok(into_transaction_builder(WasmUpdateDeleteRecordWindow(tx)))
     }
@@ -71,6 +73,7 @@ impl WasmTrailLocking {
             .trail(self.trail_id)
             .locking()
             .update_delete_trail_lock(lock.into())
+            .wasm_result()?
             .into_inner();
         Ok(into_transaction_builder(WasmUpdateDeleteTrailLock(tx)))
     }

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -927,7 +927,8 @@ impl WasmLockingWindow {
         Self(LockingWindow::TimeBased { seconds })
     }
 
-    /// Creates a count-based delete window.
+    /// Creates a count-based delete window that protects the last `count`
+    /// records currently present in trail order.
     #[wasm_bindgen(js_name = withCountBased)]
     pub fn with_count_based(count: u64) -> Self {
         Self(LockingWindow::CountBased { count })

--- a/examples/audit-trail/01_create_audit_trail.rs
+++ b/examples/audit-trail/01_create_audit_trail.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
             Some("event:shipment_created;location:warehouse-a".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/02_add_and_read_records.rs
+++ b/examples/audit-trail/02_add_and_read_records.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
             Some("event:trail_created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/03_update_metadata.rs
+++ b/examples/audit-trail/03_update_metadata.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/04_configure_locking.rs
+++ b/examples/audit-trail/04_configure_locking.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;
@@ -127,13 +127,13 @@ async fn main() -> Result<()> {
     locking_admin_client
         .trail(trail_id)
         .locking()
-        .update_delete_record_window(LockingWindow::CountBased { count: 2 })
+        .update_delete_record_window(LockingWindow::CountBased { count: 2 })?
         .build_and_execute(&locking_admin_client)
         .await?;
     locking_admin_client
         .trail(trail_id)
         .locking()
-        .update_delete_trail_lock(TimeLock::Infinite)
+        .update_delete_trail_lock(TimeLock::Infinite)?
         .build_and_execute(&locking_admin_client)
         .await?;
 

--- a/examples/audit-trail/05_manage_access.rs
+++ b/examples/audit-trail/05_manage_access.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
             None,
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/06_delete_records.rs
+++ b/examples/audit-trail/06_delete_records.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/07_access_read_only_methods.rs
+++ b/examples/audit-trail/07_access_read_only_methods.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/08_delete_audit_trail.rs
+++ b/examples/audit-trail/08_delete_audit_trail.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/README.md
+++ b/examples/audit-trail/README.md
@@ -129,7 +129,7 @@ When issuing a capability, `CapabilityIssueOptions` allows restricting its use:
 Trails support three independent lock dimensions:
 
 - **Write lock** (`TimeLock`): Prevents new records from being added
-- **Delete-record window** (`LockingWindow`): Time-based or count-based window during which a record can be deleted after creation
+- **Delete-record window** (`LockingWindow`): Time-based window or count-based protection for the last N records currently present in trail order
 - **Delete-trail lock** (`TimeLock`): Prevents the trail itself from being destroyed
 
 `TimeLock` variants: `None`, `UnlockAt(u32)`, `UnlockAtMs(u64)`, `UntilDestroyed`, `Infinite`.
@@ -147,7 +147,7 @@ Trails support three independent lock dimensions:
 ### Compliance Use Cases
 
 - **Locked write windows** to prevent retroactive record insertion
-- **Delete-record windows** to allow corrections within a time limit, then freeze
+- **Delete-record windows** to allow corrections within a time limit or retain the latest N current records
 - **Role separation** to enforce least-privilege access (auditors can read, operators can write)
 - **Bound capabilities** to tie a capability to a specific operator address
 

--- a/examples/audit-trail/advanced/09_tagged_records.rs
+++ b/examples/audit-trail/advanced/09_tagged_records.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
             Some("event:created".to_string()),
             None,
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/advanced/10_capability_constraints.rs
+++ b/examples/audit-trail/advanced/10_capability_constraints.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     let created_trail = admin_client
         .create_trail()
         .with_initial_record(InitialRecord::new(Data::text("Trail created"), None, None))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/advanced/11_manage_record_tags.rs
+++ b/examples/audit-trail/advanced/11_manage_record_tags.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
         .create_trail()
         .with_record_tags(["finance"])
         .with_initial_record(InitialRecord::new(Data::text("Trail created"), None, None))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/real-world/01_customs_clearance.rs
+++ b/examples/audit-trail/real-world/01_customs_clearance.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
             Some("event:case_opened".to_string()),
             Some("documents".to_string()),
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;

--- a/examples/audit-trail/real-world/02_clinical_trial.rs
+++ b/examples/audit-trail/real-world/02_clinical_trial.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
             Some("event:trial_opened".to_string()),
             Some("enrollment".to_string()),
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&admin_client)
         .await?
         .output;
@@ -318,7 +318,7 @@ async fn main() -> Result<()> {
     data_safety_board_client
         .trail(trail_id)
         .locking()
-        .update_delete_trail_lock(TimeLock::Infinite)
+        .update_delete_trail_lock(TimeLock::Infinite)?
         .build_and_execute(&data_safety_board_client)
         .await?;
 

--- a/examples/audit-trail/real-world/03_digital_product_passport.rs
+++ b/examples/audit-trail/real-world/03_digital_product_passport.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<()> {
             Some("event:dpp_created".to_string()),
             Some("manufacturing".to_string()),
         ))
-        .finish()
+        .finish()?
         .build_and_execute(&manufacturer_client)
         .await?
         .output;


### PR DESCRIPTION
# Description of change

Fixes two audit-trail Move security audit findings.

- Adds the missing `Migrate` permission to the default Admin permission set, so Admin capabilities can authorize package migration.
- Adds regression coverage proving Admin permissions include migration.
- Changes `CountBased(N)` delete-record locking to protect the last N records currently present in trail order, instead of using monotonic sequence-number distance.
- Uses `linked_table::back()` and `linked_table::prev()` to evaluate the protected tail window after deletions.
- Adds a tail-deletion regression test covering the case where a deleted tail record moves older records into the protected count window.
- Updates Rust, WASM, and example docs to describe the current-record semantics and the linear gas trade-off for large count windows.

## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes #issue_number`. -->

## Type of change

<!-- Choose a type of change from the list below -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
