### PR TITLE
Split product-specific workflow publishing and docs uploads

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -11,6 +11,13 @@ on:
       ref:
         description: "Optional git ref to checkout before building docs"
         required: false
+      product:
+        description: "Which product docs to publish"
+        required: true
+        type: choice
+        options:
+          - notarization
+          - audit-trail
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -20,6 +27,7 @@ permissions:
 
 jobs:
   build-wasm-notarization:
+    if: ${{ github.event_name == 'release' || github.event.inputs.product == 'notarization' }}
     uses: "./.github/workflows/shared-build-wasm.yml"
     with:
       run-unit-tests: false
@@ -27,6 +35,7 @@ jobs:
       output-artifact-name: notarization-docs
 
   build-wasm-audit-trail:
+    if: ${{ github.event_name == 'release' || github.event.inputs.product == 'audit-trail' }}
     uses: "./.github/workflows/shared-build-wasm.yml"
     with:
       run-unit-tests: false
@@ -35,14 +44,40 @@ jobs:
       wasm-package-dir: bindings/wasm/audit_trail_wasm
       wasm-crate-name: audit_trail_wasm
 
-  upload-docs:
+  upload-notarization-docs:
     runs-on: ubuntu-latest
-    needs: [build-wasm-notarization, build-wasm-audit-trail]
+    needs: [build-wasm-notarization]
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: notarization-docs
           path: notarization-docs
+      - name: Get release version
+        id: get_release_version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            INPUT_VERSION="${{ github.ref }}"
+          else
+            INPUT_VERSION="${{ github.event.inputs.version }}"
+          fi
+          VERSION=$(echo $INPUT_VERSION | sed -e 's/.*v\([0-9]*\.[0-9]*\).*/\1/')
+          echo VERSION=$VERSION >> $GITHUB_OUTPUT
+      - name: Compress generated docs
+        run: |
+          tar czvf wasm.tar.gz notarization-docs/docs/*
+
+      - name: Upload notarization docs to AWS S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_IOTA_WIKI }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_IOTA_WIKI }}
+          AWS_DEFAULT_REGION: "eu-central-1"
+        run: |
+          aws s3 cp wasm.tar.gz s3://files.iota.org/iota-wiki/iota-notarization/${{ steps.get_release_version.outputs.VERSION }}/ --acl public-read
+
+  upload-audit-trail-docs:
+    runs-on: ubuntu-latest
+    needs: [build-wasm-audit-trail]
+    steps:
       - uses: actions/download-artifact@v4
         with:
           name: audit-trail-docs
@@ -59,16 +94,7 @@ jobs:
           echo VERSION=$VERSION >> $GITHUB_OUTPUT
       - name: Compress generated docs
         run: |
-          tar czvf wasm.tar.gz notarization-docs/docs/*
           tar czvf audit-trail-wasm.tar.gz audit-trail-docs/docs/*
-
-      - name: Upload notarization docs to AWS S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_IOTA_WIKI }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_IOTA_WIKI }}
-          AWS_DEFAULT_REGION: "eu-central-1"
-        run: |
-          aws s3 cp wasm.tar.gz s3://files.iota.org/iota-wiki/iota-notarization/${{ steps.get_release_version.outputs.VERSION }}/ --acl public-read
 
       - name: Upload audit trail docs to AWS S3
         env:


### PR DESCRIPTION
## Summary
- Add explicit product selection to the docs upload workflow so notarization and audit-trail docs can be published independently.
- Clean up workflow inputs for WASM publishing and retagging so each product is chosen directly instead of relying on shared plumbing.
- Refresh the audit-trail package docs, examples, and release/publish metadata alongside the workflow changes.

## Testing
- YAML/workflow shape validated locally.
- Formatting and repo checks passed where applicable.
- Not run (not requested) for the full CI workflow matrix.