### PR TITLE
New `Naming Conventions` section in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,46 +6,46 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 IOTA Notarization enables creation of immutable, on-chain records for arbitrary data by storing it (or a hash) in dedicated Move objects on the IOTA ledger. The workspace has two components: **Notarization** (creating tamper-proof records) and **Audit Trail** (structured, role-based audit logging).
 
-## Naming Conventions 
+## Naming Conventions
 
-* Everything contained in this repository is part of the **Notarization Toolkit** - do not use synonyms like "Notarization Suite",
+- Everything contained in this repository is part of the **Notarization Toolkit** - do not use synonyms like "Notarization Suite",
   "Notarization SDK" or similar labels for the Notarization Toolkit.
-* The Notarization Toolkit is part of the IOTA Trust Framework
-* The IOTA Trust Framework consist of Trust Framework Products (TF products)
-* The Notarization Toolkit contains two TF products: **Single Notarization** and **Audit Trail**
-  * In the context of Notarization Toolkit documentation, Single Notarization and Audit Trail are called components 
-  * In the context of IOTA Trust Framework documentation, Single Notarization and Audit Trail are called TF products
-  * These rules also apply to future TF products in the Notarization Toolkit (i.e. "Proof of Inclusion")
-* The name of TF products resp. Notarization Toolkit components is allways a singular term
-  * Use capitalization (a.k.a. title case) for the words of a product name if the product is meant itself - examples `Audit Trail`, `Notarization`
-  * Use plural (i.e. `audit trails` or `notarizations`) only where multiple instances of the TF product are meant
-    * Use lower case for the plural form - except at the beginning of sentences and in markdown titles
-  * In situations where the TF product itself or the plural form can be addressed choose whatever fits best
-  * This rule - including capitalization aspects - only applies to TF products resp. Notarization Toolkit components using
+- The Notarization Toolkit is part of the IOTA Trust Framework
+- The IOTA Trust Framework consist of Trust Framework Products (TF products)
+- The Notarization Toolkit contains two TF products: **Single Notarization** and **Audit Trail**
+  - In the context of Notarization Toolkit documentation, Single Notarization and Audit Trail are called components
+  - In the context of IOTA Trust Framework documentation, Single Notarization and Audit Trail are called TF products
+  - These rules also apply to future TF products in the Notarization Toolkit (i.e. "Proof of Inclusion")
+- The name of TF products resp. Notarization Toolkit components is allways a singular term
+  - Use capitalization (a.k.a. title case) for the words of a product name if the product is meant itself - examples `Audit Trail`, `Notarization`
+  - Use plural (i.e. `audit trails` or `notarizations`) only where multiple instances of the TF product are meant
+    - Use lower case for the plural form - except at the beginning of sentences and in markdown titles
+  - In situations where the TF product itself or the plural form can be addressed choose whatever fits best
+  - This rule - including capitalization aspects - only applies to TF products resp. Notarization Toolkit components using
     plural for other entities like i.e. Notarization Methods (`Locked Notarization`, `Dynamic Notarization` - see below) is OK.
-  * Example `Audit Trail`:
-    * Do not use `Audit Trails` - always use `Audit Trail` to denote the product itself
-    * Use plural (i.e. `audit trails` or `Audit trails`) only where multiple instances of the TF product are meant - Examples:
-      * `A client for creating and managing audit trails on the IOTA blockchain`
-      * `Audit trails and their records are ...`
-      * `Audit trails provide ...` (could also be `Audit Trail provides ...`)
-* Regarding Single Notarization (Component/TF product):
-  * Single Notarization provides two **Notarization Methods**: **Locked Notarization** and **Dynamic Notarization**
-    * There might be additional Notarization Methods in future versions of Single Notarization (i.e. "Custom Notarization")
-    * For Notarization Methods, the following can be used to describe or identify the method (whatever suites into the context the best):
-      * Short Name: `Locked`, `Dynamic`, ...
-      * Full Name: `Locked Notarization`, `Dynamic Notarization`, ...
-* Each TF product/component provides packages for Move, Rust and WASM/TypeScript:
-  * Do not use terms like `toolkit`, `SDK`, ... for the packages - only use the term `Package`
-  * Aspects regarding the use of `Package` for software development in general: 
-    * For Move the term `Package` is allways used
-    * In Rust contexts, the term `Package` denotes a bundle of one or more crates containing a Cargo. toml file. Use the term
+  - Example `Audit Trail`:
+    - Do not use `Audit Trails` - always use `Audit Trail` to denote the product itself
+    - Use plural (i.e. `audit trails` or `Audit trails`) only where multiple instances of the TF product are meant - Examples:
+      - `A client for creating and managing audit trails on the IOTA blockchain`
+      - `Audit trails and their records are ...`
+      - `Audit trails provide ...` (could also be `Audit Trail provides ...`)
+- Regarding Single Notarization (Component/TF product):
+  - Single Notarization provides two **Notarization Methods**: **Locked Notarization** and **Dynamic Notarization**
+    - There might be additional Notarization Methods in future versions of Single Notarization (i.e. "Custom Notarization")
+    - For Notarization Methods, the following can be used to describe or identify the method (whatever suites into the context the best):
+      - Short Name: `Locked`, `Dynamic`, ...
+      - Full Name: `Locked Notarization`, `Dynamic Notarization`, ...
+- Each TF product/component provides packages for Move, Rust and WASM/TypeScript:
+  - Do not use terms like `toolkit`, `SDK`, ... for the packages - only use the term `Package`
+  - Aspects regarding the use of `Package` for software development in general:
+    - For Move the term `Package` is allways used
+    - In Rust contexts, the term `Package` denotes a bundle of one or more crates containing a Cargo. toml file. Use the term
       `Crate` and `Package` whatever suites into the context the best
-    * For WASM:
-      * The term `Package` can have two meanings:
-        * The WASM-Rust package containing the WASM binding code
-        * The JS/TS package created out of the WASM-Rust binding code using wasm-bindgen
-      * In most contexts this doesn't need to be distinguished, so just use the term `Package`
+    - For WASM:
+      - The term `Package` can have two meanings:
+        - The WASM-Rust package containing the WASM binding code
+        - The JS/TS package created out of the WASM-Rust binding code using wasm-bindgen
+      - In most contexts this doesn't need to be distinguished, so just use the term `Package`
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,48 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-IOTA Notarization enables creation of immutable, on-chain records for arbitrary data by storing it (or a hash) in dedicated Move objects on the IOTA ledger. The workspace has two main subsystems: **Notarization** (creating tamper-proof records) and **Audit Trails** (structured, role-based audit logging).
+IOTA Notarization enables creation of immutable, on-chain records for arbitrary data by storing it (or a hash) in dedicated Move objects on the IOTA ledger. The workspace has two components: **Notarization** (creating tamper-proof records) and **Audit Trail** (structured, role-based audit logging).
+
+## Naming Conventions 
+
+* Everything contained in this repository is part of the **Notarization Toolkit** - do not use synonyms like "Notarization Suite",
+  "Notarization SDK" or similar labels for the Notarization Toolkit.
+* The Notarization Toolkit is part of the IOTA Trust Framework
+* The IOTA Trust Framework consist of Trust Framework Products (TF products)
+* The Notarization Toolkit contains two TF products: **Single Notarization** and **Audit Trail**
+  * In the context of Notarization Toolkit documentation, Single Notarization and Audit Trail are called components 
+  * In the context of IOTA Trust Framework documentation, Single Notarization and Audit Trail are called TF products
+  * These rules also apply to future TF products in the Notarization Toolkit (i.e. "Proof of Inclusion")
+* The name of TF products resp. Notarization Toolkit components is allways a singular term
+  * Use capitalization (a.k.a. title case) for the words of a product name if the product is meant itself - examples `Audit Trail`, `Notarization`
+  * Use plural (i.e. `audit trails` or `notarizations`) only where multiple instances of the TF product are meant
+    * Use lower case for the plural form - except at the beginning of sentences and in markdown titles
+  * In situations where the TF product itself or the plural form can be addressed choose whatever fits best
+  * This rule - including capitalization aspects - only applies to TF products resp. Notarization Toolkit components using
+    plural for other entities like i.e. Notarization Methods (`Locked Notarization`, `Dynamic Notarization` - see below) is OK.
+  * Example `Audit Trail`:
+    * Do not use `Audit Trails` - always use `Audit Trail` to denote the product itself
+    * Use plural (i.e. `audit trails` or `Audit trails`) only where multiple instances of the TF product are meant - Examples:
+      * `A client for creating and managing audit trails on the IOTA blockchain`
+      * `Audit trails and their records are ...`
+      * `Audit trails provide ...` (could also be `Audit Trail provides ...`)
+* Regarding Single Notarization (Component/TF product):
+  * Single Notarization provides two **Notarization Methods**: **Locked Notarization** and **Dynamic Notarization**
+    * There might be additional Notarization Methods in future versions of Single Notarization (i.e. "Custom Notarization")
+    * For Notarization Methods, the following can be used to describe or identify the method (whatever suites into the context the best):
+      * Short Name: `Locked`, `Dynamic`, ...
+      * Full Name: `Locked Notarization`, `Dynamic Notarization`, ...
+* Each TF product/component provides packages for Move, Rust and WASM/TypeScript:
+  * Do not use terms like `toolkit`, `SDK`, ... for the packages - only use the term `Package`
+  * Aspects regarding the use of `Package` for software development in general: 
+    * For Move the term `Package` is allways used
+    * In Rust contexts, the term `Package` denotes a bundle of one or more crates containing a Cargo. toml file. Use the term
+      `Crate` and `Package` whatever suites into the context the best
+    * For WASM:
+      * The term `Package` can have two meanings:
+        * The WASM-Rust package containing the WASM binding code
+        * The JS/TS package created out of the WASM-Rust binding code using wasm-bindgen
+      * In most contexts this doesn't need to be distinguished, so just use the term `Package`
 
 ## Common Commands
 
@@ -87,7 +128,7 @@ cargo run --release --example <example_name_goes_here>
 
 The `eval` form is required because the publish script prints shell `export` statements for two variables:
 
-- `IOTA_AUDIT_TRAIL_PKG_ID` — the audit trail package ID
+- `IOTA_AUDIT_TRAIL_PKG_ID` — the Audit Trail package ID
 - `IOTA_TF_COMPONENTS_PKG_ID` — the TfComponents package ID (equals `IOTA_AUDIT_TRAIL_PKG_ID` on localnet)
 
 ## Developing Examples
@@ -96,7 +137,7 @@ The `eval` form is required because the publish script prints shell `export` sta
 
 1. Create the source file under `examples/notarization/` or `examples/audit-trail/`.
 2. Add an `[[example]]` entry to `examples/Cargo.toml` pointing to the new file.
-3. Use `examples::get_funded_notarization_client()` (notarization) or `examples::get_funded_audit_trail_client()` (audit trail) from `examples/utils/utils.rs` to obtain a funded, signed client. Do not inline client construction in example files.
+3. Use `examples::get_funded_notarization_client()` (notarization) or `examples::get_funded_audit_trail_client()` (Audit Trail) from `examples/utils/utils.rs` to obtain a funded, signed client. Do not inline client construction in example files.
 
 ### Audit Trail example patterns
 
@@ -163,11 +204,13 @@ The root `Cargo.toml` defines a workspace with members: `notarization-rs`, `audi
 
 - **`notarization-rs/`** — Rust client library for notarization
 - **`notarization-move/`** — Move smart contracts for notarization
-- **`audit-trail-rs/`** — Rust client library for audit trails
-- **`audit-trail-move/`** — Move smart contracts for audit trails
+- **`audit-trail-rs/`** — Rust client library for Audit Trail
+- **`audit-trail-move/`** — Move smart contracts for Audit Trail
 - **`bindings/wasm/notarization_wasm/`** — JS/TS WASM bindings for notarization
-- **`bindings/wasm/audit_trail_wasm/`** — JS/TS WASM bindings for audit trails
+- **`bindings/wasm/audit_trail_wasm/`** — JS/TS WASM bindings for Audit Trail
 - **`examples/`** — Rust examples (basic CRUD + real-world scenarios like IoT, legal contracts)
+
+When performing checks and edits always ignore the folders and files defined in the `.gitignore` file.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 - [Single Notarization Move](./notarization-move)
 - [Audit Trail Move](./audit-trail-move)
 
-### I want application SDKs
+### I want a toolkit to build an application
 
 - [Single Notarization Rust](./notarization-rs)
 - [Audit Trail Rust](./audit-trail-rs)

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ The suite includes:
 
 - **Single Notarization**
   Use this for individual locked or dynamic notarizations of arbitrary data, documents, hashes, or latest-state records.
-- **Audit Trails**
+- **Audit Trail**
   Use this for structured record histories with sequential entries, role-based access control, locking, and tagging.
 
 Each suite component is available as:
 
-- a **Move package** for the on-chain contracts
-- a **Rust SDK** for typed client access and transaction builders
+- a **Move Package** for the on-chain contracts
+- a **Rust Package** for typed client access and transaction builders
 - **wasm bindings** for JavaScript and TypeScript integrations
 
 ## Where To Start
@@ -43,64 +43,64 @@ Each suite component is available as:
 
 Use **Single Notarization** when your main need is proving the existence, integrity, or latest state of one notarized object on-chain.
 
-- [Single Notarization Rust SDK](./notarization-rs)
+- [Single Notarization Rust Package](./notarization-rs)
 - [Single Notarization Move Package](./notarization-move)
-- [Single Notarization Wasm SDK](./bindings/wasm/notarization_wasm)
+- [Single Notarization Wasm Package](./bindings/wasm/notarization_wasm)
 - [Single Notarization examples](./bindings/wasm/notarization_wasm/examples/README.md)
 
 ### I want an audit trail
 
-Use **Audit Trails** when you need a structured record history with permissions, capabilities, tagging, and write or delete controls.
+Use **Audit Trail** when you need a structured record history with permissions, capabilities, tagging, and write or delete controls.
 
-- [Audit Trails Rust SDK](./audit-trail-rs)
-- [Audit Trails Move Package](./audit-trail-move)
-- [Audit Trails Wasm SDK](./bindings/wasm/audit_trail_wasm)
-- [Audit Trails examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
+- [Audit Trail Rust Package](./audit-trail-rs)
+- [Audit Trail Move Package](./audit-trail-move)
+- [Audit Trail Wasm Package](./bindings/wasm/audit_trail_wasm)
+- [Audit Trail examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
 
 ### I want the on-chain contracts
 
 - [Single Notarization Move](./notarization-move)
-- [Audit Trails Move](./audit-trail-move)
+- [Audit Trail Move](./audit-trail-move)
 
 ### I want application SDKs
 
 - [Single Notarization Rust](./notarization-rs)
-- [Audit Trails Rust](./audit-trail-rs)
+- [Audit Trail Rust](./audit-trail-rs)
 - [Single Notarization Wasm](./bindings/wasm/notarization_wasm)
-- [Audit Trails Wasm](./bindings/wasm/audit_trail_wasm)
+- [Audit Trail Wasm](./bindings/wasm/audit_trail_wasm)
 
 ## Suite Components
 
-| Component           | Best for                                                                    | Move Package                               | Rust SDK                               | Wasm SDK                                                 |
-| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------- | -------------------------------------------------------- |
+| Component           | Best for                                                                    | Move Package                               | Rust Package                           | Wasm Package                                             |
+|---------------------|-----------------------------------------------------------------------------|--------------------------------------------|----------------------------------------|----------------------------------------------------------|
 | Single Notarization | Individual locked or dynamic notarizations for documents, hashes, and state | [`notarization-move`](./notarization-move) | [`notarization-rs`](./notarization-rs) | [`notarization_wasm`](./bindings/wasm/notarization_wasm) |
-| Audit Trails        | Shared sequential records with roles, capabilities, tagging, and locking    | [`audit-trail-move`](./audit-trail-move)   | [`audit-trail-rs`](./audit-trail-rs)   | [`audit_trail_wasm`](./bindings/wasm/audit_trail_wasm)   |
+| Audit Trail         | Shared sequential records with roles, capabilities, tagging, and locking    | [`audit-trail-move`](./audit-trail-move)   | [`audit-trail-rs`](./audit-trail-rs)   | [`audit_trail_wasm`](./bindings/wasm/audit_trail_wasm)   |
 
 ### Which one should I use?
 
 | Need                                                                      | Best fit            |
-| ------------------------------------------------------------------------- | ------------------- |
+| ------------------------------------------------------------------------- |---------------------|
 | Locked proof object for arbitrary data                                    | Single Notarization |
 | Dynamic latest-state notarization flow                                    | Single Notarization |
-| Shared sequential records with roles, capabilities, and record tag policy | Audit Trails        |
-| Team or system audit log with governance and operational controls         | Audit Trails        |
+| Shared sequential records with roles, capabilities, and record tag policy | Audit Trail         |
+| Team or system audit log with governance and operational controls         | Audit Trail         |
 
 ## Documentation And Resources
 
 ### Single Notarization
 
-- [Single Notarization Rust SDK README](./notarization-rs/README.md)
+- [Single Notarization Rust Package README](./notarization-rs/README.md)
 - [Single Notarization Move Package README](./notarization-move/README.md)
-- [Single Notarization Wasm README](./bindings/wasm/notarization_wasm/README.md)
+- [Single Notarization Wasm Package README](./bindings/wasm/notarization_wasm/README.md)
 - [Single Notarization examples](./bindings/wasm/notarization_wasm/examples/README.md)
 - [IOTA Notarization Docs Portal](https://docs.iota.org/developer/iota-notarization)
 
-### Audit Trails
+### Audit Trail
 
-- [Audit Trails Rust SDK README](./audit-trail-rs/README.md)
-- [Audit Trails Move Package README](./audit-trail-move/README.md)
-- [Audit Trails Wasm README](./bindings/wasm/audit_trail_wasm/README.md)
-- [Audit Trails examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
+- [Audit Trail Rust Package README](./audit-trail-rs/README.md)
+- [Audit Trail Move Package README](./audit-trail-move/README.md)
+- [Audit Trail Wasm Package README](./bindings/wasm/audit_trail_wasm/README.md)
+- [Audit Trail examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
 
 ### Shared
 
@@ -111,7 +111,7 @@ Use **Audit Trails** when you need a structured record history with permissions,
 [Foreign Function Interface (FFI)](https://en.wikipedia.org/wiki/Foreign_function_interface) bindings available in this repository:
 
 - [Web Assembly for Single Notarization](./bindings/wasm/notarization_wasm)
-- [Web Assembly for Audit Trails](./bindings/wasm/audit_trail_wasm)
+- [Web Assembly for Audit Trail](./bindings/wasm/audit_trail_wasm)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="#introduction">Introduction</a> ◈
   <a href="#where-to-start">Where To Start</a> ◈
-  <a href="#suite-components">Suite Components</a> ◈
+  <a href="#toolkit-components">Toolkit Components</a> ◈
   <a href="#documentation-and-resources">Documentation & Resources</a> ◈
   <a href="#bindings">Bindings</a> ◈
   <a href="#contributing">Contributing</a>
@@ -18,20 +18,20 @@
 
 ---
 
-# IOTA Notarization Suite
+# IOTA Notarization Toolkit
 
 ## Introduction
 
-This repository contains the IOTA Notarization Suite, a set of IOTA ledger tools for verifiable on-chain data workflows.
+This repository contains the IOTA Notarization Toolkit, a set of IOTA ledger tools for verifiable on-chain data workflows.
 
-The suite includes:
+The toolkit includes:
 
 - **Single Notarization**
   Use this for individual locked or dynamic notarizations of arbitrary data, documents, hashes, or latest-state records.
 - **Audit Trail**
   Use this for structured record histories with sequential entries, role-based access control, locking, and tagging.
 
-Each suite component is available as:
+Each toolkit component is available as:
 
 - a **Move Package** for the on-chain contracts
 - a **Rust Package** for typed client access and transaction builders
@@ -69,7 +69,7 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 - [Single Notarization Wasm](./bindings/wasm/notarization_wasm)
 - [Audit Trail Wasm](./bindings/wasm/audit_trail_wasm)
 
-## Suite Components
+## Toolkit Components
 
 | Component           | Best for                                                                    | Move Package                               | Rust Package                           | Wasm Package                                             |
 |---------------------|-----------------------------------------------------------------------------|--------------------------------------------|----------------------------------------|----------------------------------------------------------|
@@ -115,7 +115,7 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 
 ## Contributing
 
-We would love to have you help us with the development of the IOTA Notarization Suite. Each and every contribution is greatly valued.
+We would love to have you help us with the development of the IOTA Notarization Toolkit. Each and every contribution is greatly valued.
 
 Please review the [contribution](https://docs.iota.org/developer/iota-notarization/contribute) sections in the [IOTA Docs Portal](https://docs.iota.org/developer/iota-notarization/).
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 ## Toolkit Components
 
 | Component           | Best for                                                                    | Move Package                               | Rust Package                           | Wasm Package                                             |
-|---------------------|-----------------------------------------------------------------------------|--------------------------------------------|----------------------------------------|----------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------- | -------------------------------------------------------- |
 | Single Notarization | Individual locked or dynamic notarizations for documents, hashes, and state | [`notarization-move`](./notarization-move) | [`notarization-rs`](./notarization-rs) | [`notarization_wasm`](./bindings/wasm/notarization_wasm) |
 | Audit Trail         | Shared sequential records with roles, capabilities, tagging, and locking    | [`audit-trail-move`](./audit-trail-move)   | [`audit-trail-rs`](./audit-trail-rs)   | [`audit_trail_wasm`](./bindings/wasm/audit_trail_wasm)   |
 
 ### Which one should I use?
 
 | Need                                                                      | Best fit            |
-| ------------------------------------------------------------------------- |---------------------|
+| ------------------------------------------------------------------------- | ------------------- |
 | Locked proof object for arbitrary data                                    | Single Notarization |
 | Dynamic latest-state notarization flow                                    | Single Notarization |
 | Shared sequential records with roles, capabilities, and record tag policy | Audit Trail         |

--- a/audit-trail-move/README.md
+++ b/audit-trail-move/README.md
@@ -71,12 +71,12 @@ cd audit-trail-move
 
 The publish script prints `IOTA_AUDIT_TRAIL_PKG_ID` and, on `localnet`, also exports `IOTA_TF_COMPONENTS_PKG_ID`.
 
-The package history files [`Move.lock`](./Move.lock) and [`Move.history.json`](./Move.history.json) are used by the Rust SDK to resolve and track deployed package versions.
+The package history files [`Move.lock`](./Move.lock) and [`Move.history.json`](./Move.history.json) are used by the Rust crate to resolve and track deployed package versions.
 
 ## Related Libraries
 
-- [Rust SDK](https://github.com/iotaledger/notarization/tree/main/audit-trail-rs/README.md)
-- [Wasm SDK](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/README.md)
+- [Rust Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-rs/README.md)
+- [Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/README.md)
 - [Repository Root](https://github.com/iotaledger/notarization/tree/main/README.md)
 
 ## Contributing

--- a/audit-trail-move/sources/record_tags.move
+++ b/audit-trail-move/sources/record_tags.move
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Record tag types and helper predicates for audit trails.
+/// Record tag types and helper predicates for Audit Trail.
 module audit_trail::record_tags;
 
 use audit_trail::permission::Permission;

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Audit Trail Rust Package provides the Rust client for structured record histories in the IOTA Notarization Suite.
+The Audit Trail Rust Package provides the Rust client for structured record histories in the IOTA Notarization Toolkit.
 
 The package also provides an `AuditTrailBuilder` that creates audit trail objects on the IOTA ledger and an `AuditTrailHandle`
 that interacts with existing trails. The handle maps to one on-chain audit trail and provides typed APIs for records,
@@ -12,7 +12,7 @@ Use Audit Trail when you need a governed record history with sequential entries,
 locking, and tagging. Use Single Notarization when you need one locked or dynamic notarized object for arbitrary data,
 documents, hashes, or latest-state records.
 
-You can find the full IOTA Notarization Suite documentation [here](https://docs.iota.org/developer/iota-notarization).
+You can find the full IOTA Notarization Toolkit documentation [here](https://docs.iota.org/developer/iota-notarization).
 
 ## Process Flows
 
@@ -245,7 +245,7 @@ The trail deletion process does not remove records automatically. The trail must
 - [Audit Trail Move Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-move): On-chain contract package that defines the shared object model, permissions, locking, and events.
 - [Audit Trail Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm): JavaScript and TypeScript bindings for browser and Node.js integrations.
 - [Audit Trail Wasm Examples](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/examples/README.md): Runnable audit-trail examples for JS and TS consumers.
-- [Repository Examples](https://github.com/iotaledger/notarization/tree/main/examples/README.md): End-to-end examples across the Notarization Suite.
+- [Repository Examples](https://github.com/iotaledger/notarization/tree/main/examples/README.md): End-to-end examples across the Notarization Toolkit.
 
 This README is also used as the crate-level rustdoc entry point, while the source files provide detailed API documentation for all public types and methods.
 
@@ -257,7 +257,7 @@ This README is also used as the crate-level rustdoc entry point, while the sourc
 
 ## Contributing
 
-We would love to have you help us with the development of the IOTA Notarization Suite. Each and every contribution is greatly valued.
+We would love to have you help us with the development of the IOTA Notarization Toolkit. Each and every contribution is greatly valued.
 
 Please review the [contribution](https://docs.iota.org/developer/iota-notarization/contribute) sections in the [IOTA Docs Portal](https://docs.iota.org/developer/iota-notarization/).
 

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -1,14 +1,14 @@
-# IOTA Audit Trails Rust SDK
+# IOTA Audit Trail Rust Package
 
 ## Introduction
 
-The Audit Trails Rust SDK is the Rust client for structured record histories in the IOTA Notarization Suite.
+The Audit Trail Rust Package provides the Rust client for structured record histories in the IOTA Notarization Suite.
 
-The SDK provides an `AuditTrailBuilder` that creates audit trail objects on the IOTA ledger and an `AuditTrailHandle`
+The package also provides an `AuditTrailBuilder` that creates audit trail objects on the IOTA ledger and an `AuditTrailHandle`
 that interacts with existing trails. The handle maps to one on-chain audit trail and provides typed APIs for records,
 access control, locking, tags, metadata, migration, and deletion.
 
-Use Audit Trails when you need a governed record history with sequential entries, role-based permissions, capabilities,
+Use Audit Trail when you need a governed record history with sequential entries, role-based permissions, capabilities,
 locking, and tagging. Use Single Notarization when you need one locked or dynamic notarized object for arbitrary data,
 documents, hashes, or latest-state records.
 
@@ -242,16 +242,16 @@ The trail deletion process does not remove records automatically. The trail must
 
 ## Documentation And Resources
 
-- [Audit Trails Move Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-move): On-chain contract package that defines the shared object model, permissions, locking, and events.
-- [Audit Trails Wasm SDK](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm): JavaScript and TypeScript bindings for browser and Node.js integrations.
-- [Audit Trails Wasm Examples](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/examples/README.md): Runnable audit-trail examples for JS and TS consumers.
+- [Audit Trail Move Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-move): On-chain contract package that defines the shared object model, permissions, locking, and events.
+- [Audit Trail Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm): JavaScript and TypeScript bindings for browser and Node.js integrations.
+- [Audit Trail Wasm Examples](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/examples/README.md): Runnable audit-trail examples for JS and TS consumers.
 - [Repository Examples](https://github.com/iotaledger/notarization/tree/main/examples/README.md): End-to-end examples across the Notarization Suite.
 
 This README is also used as the crate-level rustdoc entry point, while the source files provide detailed API documentation for all public types and methods.
 
 ## Bindings
 
-[Foreign Function Interface (FFI)](https://en.wikipedia.org/wiki/Foreign_function_interface) bindings of this Rust SDK to other programming languages:
+[Foreign Function Interface (FFI)](https://en.wikipedia.org/wiki/Foreign_function_interface) bindings of this Rust crate to other programming languages:
 
 - [Web Assembly](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm) (JavaScript/TypeScript)
 

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Audit Trail Rust Package provides the Rust client for structured record histories in the IOTA Notarization Toolkit.
+The Audit Trail Rust package provides the Rust client for structured record histories in the IOTA Notarization Toolkit.
 
 The package also provides an `AuditTrailBuilder` that creates audit trail objects on the IOTA ledger and an `AuditTrailHandle`
 that interacts with existing trails. The handle maps to one on-chain audit trail and provides typed APIs for records,

--- a/audit-trail-rs/src/client/read_only.rs
+++ b/audit-trail-rs/src/client/read_only.rs
@@ -51,7 +51,7 @@ pub struct AuditTrailClientReadOnly {
     iota_client: IotaClientAdapter,
     /// The [`ObjectID`] of the deployed audit trail package (smart contract).
     audit_trail_pkg_id: ObjectID,
-    /// The [`ObjectID`] of the deployed TfComponents package used by audit trails.
+    /// The [`ObjectID`] of the deployed TfComponents package used by Audit Trail.
     pub(crate) tf_components_pkg_id: ObjectID,
     /// The name of the network this client is connected to (e.g., "mainnet", "testnet").
     network: NetworkName,

--- a/audit-trail-rs/src/core/access/mod.rs
+++ b/audit-trail-rs/src/core/access/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Role and capability management APIs for audit trails.
+//! Role and capability management APIs for Audit Trail.
 //!
 //! This module is the Rust-facing wrapper around the access-control state integrated into each audit trail.
 //! Roles grant [`crate::core::types::PermissionSet`] values, while capability objects bind one role to one trail and

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Locking configuration APIs for audit trails.
+//! Locking configuration APIs for Audit Trail.
 
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};

--- a/audit-trail-rs/src/core/mod.rs
+++ b/audit-trail-rs/src/core/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Core handles, builders, transactions, and domain types for audit trails.
+//! Core handles, builders, transactions, and domain types for Audit Trail.
 //!
 //! This namespace contains the main trail-facing Rust API:
 //!

--- a/audit-trail-rs/src/core/records/mod.rs
+++ b/audit-trail-rs/src/core/records/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Record read and mutation APIs for audit trails.
+//! Record read and mutation APIs for Audit Trail.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/audit-trail-rs/src/core/tags/mod.rs
+++ b/audit-trail-rs/src/core/tags/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Record-tag registry APIs for audit trails.
+//! Record-tag registry APIs for Audit Trail.
 
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};

--- a/audit-trail-rs/src/core/types/RoleMap-README.md
+++ b/audit-trail-rs/src/core/types/RoleMap-README.md
@@ -1,4 +1,4 @@
-# Role-Based Access Control for Audit Trails
+# Role-Based Access Control for Audit Trail
 
 Audit trails provide an access control registry (a.k.a. `RoleMap`), defining who may perform which
 operations by combining two primitives:

--- a/audit-trail-rs/src/core/types/mod.rs
+++ b/audit-trail-rs/src/core/types/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared serializable domain types for audit trails.
+//! Shared serializable domain types for Audit Trail.
 //!
 //! These types stay close to the on-chain data model so they can deserialize ledger state and events while also
 //! serving as the typed inputs and outputs of the Rust client API.

--- a/audit-trail-rs/src/core/types/record.rs
+++ b/audit-trail-rs/src/core/types/record.rs
@@ -201,7 +201,7 @@ impl Data {
             Ok(())
         } else {
             Err(Error::InvalidArgument(format!(
-                "record data type mismatch: trail expects {:?}, SDK writes {:?}",
+                "record data type mismatch: trail expects {:?}, client writes {:?}",
                 expected, actual
             )))
         }

--- a/audit-trail-rs/src/error.rs
+++ b/audit-trail-rs/src/error.rs
@@ -5,7 +5,7 @@
 
 use crate::iota_interaction_adapter::AdapterError;
 
-/// Errors that can occur when reading or mutating audit trails.
+/// Errors that can occur when reading or mutating an Audit Trail.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[non_exhaustive]
 pub enum Error {

--- a/bindings/wasm/audit_trail_wasm/README.md
+++ b/bindings/wasm/audit_trail_wasm/README.md
@@ -1,6 +1,6 @@
 # `audit_trail_wasm`
 
-`audit_trail_wasm` exposes the `audit_trail` Rust SDK to JavaScript and TypeScript consumers through `wasm-bindgen`.
+`audit_trail_wasm` exposes the `audit_trail` Rust crate to JavaScript and TypeScript consumers through `wasm-bindgen`.
 
 It is designed for browser and other `wasm32` environments that need:
 
@@ -48,7 +48,7 @@ The bindings expose JS-friendly wrappers for the most important Rust value types
 3. Convert that transaction wrapper into programmable transaction bytes.
 4. Submit it through your surrounding JS transaction flow and feed the effects and events back into the typed `applyWithEvents(...)` helper.
 
-The bindings intentionally separate transaction construction from submission so browser apps, wallet integrations, and server-side signing flows can keep transport and execution policy outside the SDK.
+The bindings intentionally separate transaction construction from submission so browser apps, wallet integrations, and server-side signing flows can keep transport and execution policy outside the package.
 
 ## Minimal TypeScript shape
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/real-world/03_digital_product_passport.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/real-world/03_digital_product_passport.ts
@@ -7,7 +7,7 @@
  * Models a Digital Product Passport (DPP) for an e-bike battery, inspired by the
  * public IOTA DPP demo.
  *
- * Scope note: this example stays within the Audit Trail SDK. The demo's wider
+ * Scope note: this example stays within the Audit Trail package. The demo's wider
  * IOTA stack (Identity, Hierarchies, Tokenization, and Gas Station) is mapped
  * here onto audit-trail-native concepts:
  *

--- a/bindings/wasm/audit_trail_wasm/src/client_read_only.rs
+++ b/bindings/wasm/audit_trail_wasm/src/client_read_only.rs
@@ -18,7 +18,7 @@ use crate::trail_handle::WasmAuditTrailHandle;
 /// {@link AuditTrailClientReadOnly.createWithPackageOverrides} or
 /// {@link AuditTrailClient.createFromIotaClientWithPackageOverrides} when the connected network
 /// hosts the audit-trail package — and optionally the `tf_components` package — at addresses that
-/// are not part of the SDK's built-in registry. Leave a field unset to fall back to the registry
+/// are not part of the audit-trail package's built-in registry. Leave a field unset to fall back to the registry
 /// lookup for that package.
 #[derive(Clone)]
 #[wasm_bindgen(js_name = PackageOverrides, getter_with_clone, inspectable)]
@@ -103,7 +103,7 @@ impl WasmAuditTrailClientReadOnly {
     ///
     /// @remarks
     /// Prefer this when targeting a local deployment, preview environment, or any package pair
-    /// that is not yet part of the SDK's built-in registry.
+    /// that is not yet part of the package's built-in registry.
     ///
     /// @param iotaClient - IOTA client used to talk to the network.
     /// @param packageOverrides - Package IDs to use instead of registry lookups.

--- a/bindings/wasm/audit_trail_wasm/src/trail.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail.rs
@@ -150,7 +150,7 @@ impl WasmOnChainAuditTrail {
     /// Returns the on-chain package version of the trail object.
     ///
     /// @remarks
-    /// Use {@link AuditTrailHandle.migrate} after a package upgrade if this lags behind the SDK's
+    /// Use {@link AuditTrailHandle.migrate} after a package upgrade if this lags behind the package's
     /// expected version.
     ///
     /// @returns Stored package version of the trail object.

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
@@ -125,13 +125,13 @@ impl WasmTrailRecords {
     ///
     /// @param cursor - Sequence-number cursor for the page boundary; pass `null` for the first
     /// page and reuse {@link PaginatedRecord.nextCursor} for subsequent pages.
-    /// @param limit - Maximum number of records to return; may not exceed the SDK-side maximum
+    /// @param limit - Maximum number of records to return; may not exceed the package-side maximum
     /// page size.
     ///
     /// @returns A {@link PaginatedRecord} carrying the loaded records and pagination metadata.
     ///
     /// @throws When the trail object cannot be fetched, a record cannot be deserialized, or
-    /// `limit` exceeds the SDK-side maximum.
+    /// `limit` exceeds the package-side maximum.
     #[wasm_bindgen(js_name = listPage)]
     pub async fn list_page(&self, cursor: Option<u64>, limit: usize) -> Result<WasmPaginatedRecord> {
         let page = self

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
@@ -125,13 +125,13 @@ impl WasmTrailRecords {
     ///
     /// @param cursor - Sequence-number cursor for the page boundary; pass `null` for the first
     /// page and reuse {@link PaginatedRecord.nextCursor} for subsequent pages.
-    /// @param limit - Maximum number of records to return; may not exceed the package-side maximum
-    /// page size.
+    /// @param limit - Maximum number of records to return; may not exceed the maximum page size defined in the
+    /// Audit Trail Rust crate.
     ///
     /// @returns A {@link PaginatedRecord} carrying the loaded records and pagination metadata.
     ///
     /// @throws When the trail object cannot be fetched, a record cannot be deserialized, or
-    /// `limit` exceeds the package-side maximum.
+    /// `limit` exceeds the maximum page size defined in the Audit Trail Rust crate.
     #[wasm_bindgen(js_name = listPage)]
     pub async fn list_page(&self, cursor: Option<u64>, limit: usize) -> Result<WasmPaginatedRecord> {
         let page = self

--- a/bindings/wasm/notarization_wasm/examples/src/gas-costs/README.md
+++ b/bindings/wasm/notarization_wasm/examples/src/gas-costs/README.md
@@ -27,11 +27,11 @@ The cost for creating a Notarization object can roughly be calculated by the fol
 Where:
 
 | Parameter            | Description                                                                                                                                                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `FlexDataSize`       | Sum of the byte sizes of State Data, State Metadata, Updatable Metadata and Immutable Metadata. The value must be reduced by 1 as the `MinimumStorageCost` uses 1 byte of State Data.                                                |
 | `FlexDataByteCost`   | A constant value of 0.0000076 IOTA/Byte <br> This value denotes (`StorageCost` - `MinimumStorageCost`) divided by `FlexDataSize`.                                                                                                    |
 | `MinimumStorageCost` | A constant value of 0.00295 IOTA. <br> This value denotes the `StorageCost` for a Notarization with 1 Byte of `FlexDataSize` meaning a Notarization with 1 Byte of State Data, no meta data and no optional locks.                   |
-| `ComputationCost`    | A constant value of 0.001 IOTA. <br> Given the Gas Price is 1000 nano, the `ComputationCost` will always be 0.001 IOTA as creating Notarizations always consume 1000 Computation Units.                                              |
+| `ComputationCost`    | A constant value of 0.001 IOTA. <br> Given the Gas Price is 1000 nano, the `ComputationCost` will always be 0.001 IOTA as creating notarizations always consumes 1000 Computation Units.                                             |
 | `TotalCost`          | The amount of IOTA that would need to be paid for gas when Storage Rebate is not taken into account. The real gas cost will be lower, due to Storage Rebate, which is usually -0.0009804 IOTA when a Notarization object is created. |
 
 Examples:

--- a/bindings/wasm/notarization_wasm/examples/src/gas-costs/README.md
+++ b/bindings/wasm/notarization_wasm/examples/src/gas-costs/README.md
@@ -27,7 +27,7 @@ The cost for creating a Notarization object can roughly be calculated by the fol
 Where:
 
 | Parameter            | Description                                                                                                                                                                                                                          |
-| -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `FlexDataSize`       | Sum of the byte sizes of State Data, State Metadata, Updatable Metadata and Immutable Metadata. The value must be reduced by 1 as the `MinimumStorageCost` uses 1 byte of State Data.                                                |
 | `FlexDataByteCost`   | A constant value of 0.0000076 IOTA/Byte <br> This value denotes (`StorageCost` - `MinimumStorageCost`) divided by `FlexDataSize`.                                                                                                    |
 | `MinimumStorageCost` | A constant value of 0.00295 IOTA. <br> This value denotes the `StorageCost` for a Notarization with 1 Byte of `FlexDataSize` meaning a Notarization with 1 Byte of State Data, no meta data and no optional locks.                   |

--- a/examples/audit-trail/README.md
+++ b/examples/audit-trail/README.md
@@ -1,6 +1,6 @@
 # IOTA Audit Trail Examples
 
-The following code examples demonstrate how to use IOTA Audit Trails for creating structured, role-based audit logs on the IOTA network.
+The following code examples demonstrate how to use IOTA Audit Trail for creating structured, role-based audit logs on the IOTA network.
 
 ## Prerequisites
 

--- a/examples/audit-trail/real-world/03_digital_product_passport.rs
+++ b/examples/audit-trail/real-world/03_digital_product_passport.rs
@@ -6,7 +6,7 @@
 //! This example models a Digital Product Passport (DPP) for an e-bike battery,
 //! inspired by the public IOTA DPP demo.
 //!
-//! Scope note: this example stays within the Audit Trail SDK. The demo's wider
+//! Scope note: this example stays within the Audit Trail package. The demo's wider
 //! IOTA stack (Identity, Hierarchies, Tokenization, and Gas Station) is mapped
 //! here onto audit-trail-native concepts:
 //!

--- a/notarization-move/README.md
+++ b/notarization-move/README.md
@@ -67,12 +67,12 @@ cd notarization-move
 ./scripts/publish_package.sh
 ```
 
-The package history files [`Move.lock`](./Move.lock) and [`Move.history.json`](./Move.history.json) are used by the Rust SDK to resolve and track deployed package versions.
+The package history files [`Move.lock`](./Move.lock) and [`Move.history.json`](./Move.history.json) are used by the Rust package to resolve and track deployed package versions.
 
 ## Related Libraries
 
-- [Rust SDK](https://github.com/iotaledger/notarization/tree/main/notarization-rs/README.md)
-- [Wasm SDK](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/notarization_wasm/README.md)
+- [Rust Package](https://github.com/iotaledger/notarization/tree/main/notarization-rs/README.md)
+- [Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/notarization_wasm/README.md)
 - [Repository Root](https://github.com/iotaledger/notarization/tree/main/README.md)
 
 ## Contributing

--- a/notarization-move/sources/notarization.move
+++ b/notarization-move/sources/notarization.move
@@ -413,7 +413,7 @@ public fun destroy<D: drop + store + copy>(self: Notarization<D>, clock: &Clock)
         timelock::destroy(delete_lock, clock);
         timelock::destroy(transfer_lock, clock);
     } else {
-        // We know dynamic Notarizations have no lock metadata
+        // We know Dynamic-Notarizations have no lock metadata
         option::destroy_none(locking);
     };
 

--- a/notarization-rs/README.md
+++ b/notarization-rs/README.md
@@ -1,14 +1,14 @@
 # IOTA Single Notarization
 
-The Single Notarization Rust SDK is the Rust client for individual locked and dynamic notarizations in the IOTA
+The Single Notarization Rust Package is the Rust client for individual locked and dynamic notarizations in the IOTA
 Notarization Suite.
 
-The SDK provides a `NotarizationBuilder` that creates notarization objects on the IOTA ledger or connects to existing
+The package provides a `NotarizationBuilder` that creates notarization objects on the IOTA ledger or connects to existing
 notarization objects. The builder returns a `Notarization` struct instance that maps to the on-chain object and provides
 typed methods for interacting with it.
 
 Use Single Notarization when you need one notarized object for arbitrary data, documents, hashes, or latest-state
-records. Use Audit Trails when you need a structured record history with roles, capabilities, locking, and tagging.
+records. Use Audit Trail when you need a structured record history with roles, capabilities, locking, and tagging.
 
 You can find the full IOTA Notarization Suite documentation [here](https://docs.iota.org/developer/iota-notarization).
 

--- a/notarization-rs/README.md
+++ b/notarization-rs/README.md
@@ -31,7 +31,7 @@ functions. The terms used here are defined in the [glossary below](#glossary).
 
 After a **dynamic** Notarization has been created, it can be updated using the `Notarization::update_state()` function
 and destroyed using `Notarization::destroy()`.
-**Locked** notarizations are immutable after creation.
+A **locked** Notarization is immutable after creation.
 
 #### Creating a new Dynamic Notarization on the Ledger
 
@@ -171,7 +171,7 @@ As the `Latest State` of a _Locked Notarization_ cannot be updated, the lifecycl
 - `Creation Timestamp`: Indicates when the `Ledger Object` was initially created.
 - `Immutable Metadata`: Consists of the `Immutable Description` and `Creation Timestamp`.
 - `Updatable Metadata`: An arbitrary informational String that can be updated at any time by the `Prover` independently
-  from the `Latest State` (dynamic notarizations only; locked notarizations are immutable). Can be used to provide
+  from the `Latest State` (Dynamic Notarizations only; Locked Notarizations are immutable). Can be used to provide
   additional useful information that is subject to change from time to time.
 - `State Version Count`: Numerical value incremented with each update of the `Latest State`.
 - `Last State Change Time`: Indicates when the `Latest State` was last updated.

--- a/notarization-rs/README.md
+++ b/notarization-rs/README.md
@@ -1,7 +1,7 @@
 # IOTA Single Notarization
 
 The Single Notarization Rust Package is the Rust client for individual locked and dynamic notarizations in the IOTA
-Notarization Suite.
+Notarization Toolkit.
 
 The package provides a `NotarizationBuilder` that creates notarization objects on the IOTA ledger or connects to existing
 notarization objects. The builder returns a `Notarization` struct instance that maps to the on-chain object and provides
@@ -10,7 +10,7 @@ typed methods for interacting with it.
 Use Single Notarization when you need one notarized object for arbitrary data, documents, hashes, or latest-state
 records. Use Audit Trail when you need a structured record history with roles, capabilities, locking, and tagging.
 
-You can find the full IOTA Notarization Suite documentation [here](https://docs.iota.org/developer/iota-notarization).
+You can find the full IOTA Notarization Toolkit documentation [here](https://docs.iota.org/developer/iota-notarization).
 
 ## Process Flows
 

--- a/notarization-rs/README.md
+++ b/notarization-rs/README.md
@@ -1,6 +1,6 @@
 # IOTA Single Notarization
 
-The Single Notarization Rust Package is the Rust client for individual locked and dynamic notarizations in the IOTA
+The Single Notarization Rust package is the Rust client for individual locked and dynamic notarizations in the IOTA
 Notarization Toolkit.
 
 The package provides a `NotarizationBuilder` that creates notarization objects on the IOTA ledger or connects to existing

--- a/notarization-rs/src/error.rs
+++ b/notarization-rs/src/error.rs
@@ -3,7 +3,7 @@
 
 use crate::iota_interaction_adapter::AdapterError;
 
-/// Errors that can occur when managing Notarizations
+/// Errors that can occur when managing notarizations
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[non_exhaustive]
 pub enum Error {


### PR DESCRIPTION
# Description of change

The root CLAUDE.md contains a new `Naming Conventions` section.

The README files and the source-docs of public exposed entities for Move, Rust and WASM/TS packages in the repository have been checked against the new `Naming Conventions` guideline and edited accordingly.