### PR TITLE
feat: Update to iota v1.23.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false, package = "product_common" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.23.2" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }
@@ -29,7 +29,7 @@ thiserror = { version = "2.0", default-features = false }
 chrono = { version = "0.4", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0", default-features = false }
 sha2 = { version = "0.10", default-features = false }
-tokio = { version = "1.49.0", default-features = false, features = ["macros", "sync", "rt", "process"] }
+tokio = { version = "1.52.2", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [profile.release.package.iota_interaction_ts]
 opt-level = 's'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ async-trait = "0.1"
 bcs = "0.1"
 hyper = "1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.23.2" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false, package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.27", default-features = false, features = ["std", "derive"] }

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -30,14 +30,14 @@ serde-wasm-bindgen = "0.6.5"
 serde_json = { version = "1.0", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
 # Want to use the nice API of tokio::sync::RwLock for now even though we can't use threads.
-tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
+tokio = { version = "1.52.2", default-features = false, features = ["sync"] }
 tsify = "0.4.5"
 wasm-bindgen = { version = "0.2.100", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.17"
+branch = "feat/iota-v1-23-rc-upstream-merge"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,8 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", package = "iota_interaction_ts" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +37,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-23-rc-upstream-merge"
+tag = "v0.8.18"
 package = "product_common"
 features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"]
 

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -35,7 +35,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.13.0"
+        "@iota/iota-sdk": "^1.14.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@iota/iota-sdk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.13.0.tgz",
-      "integrity": "sha512-ay19PRu0z+1W9tnmGyexIR/Sp0Rpt7H0mUCuEZQ5B+7O6Qf61+Co8TrR1SRIrKwD7Fu90jPy5y5MwFXy/vLwKg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.14.0.tgz",
+      "integrity": "sha512-nOq7EHD68p35nH+2c1sn/MnvEFEkRNRXTuiDYqI+SxWN1KcDuyYaSoFqz9PsQNhbdXzgbseHMo/L94LJ5jgIuA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {

--- a/bindings/wasm/notarization_wasm/package-lock.json
+++ b/bindings/wasm/notarization_wasm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@iota/iota-interaction-ts": "^0.13.0"
+        "@iota/iota-interaction-ts": "^0.14.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -312,15 +312,15 @@
       }
     },
     "node_modules/@iota/iota-interaction-ts": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.13.0.tgz",
-      "integrity": "sha512-LL4nbgEbqqa3UqXkiAnbRMW3KSqKMic0cJEEooWlTz2VtwHSOHyVwzjF2HNt7C9o2svq5uKyCkkzVAxjMI1Esg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.14.0.tgz",
+      "integrity": "sha512-LojlV7UL/cMERaJqw1IBeL9bWSJPJ91kiOQ6kWTUH775kuWLixx0JBJJINGpbQVZXIsUV0T62nbipVfk+JferA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.13.0"
+        "@iota/iota-sdk": "^1.14.0"
       }
     },
     "node_modules/@iota/iota-sdk": {

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -75,7 +75,7 @@
     "@iota/iota-interaction-ts": "^0.13.0"
   },
   "peerDependencies": {
-    "@iota/iota-sdk": "^1.13.0"
+    "@iota/iota-sdk": "^1.14.0"
   },
   "engines": {
     "node": ">=20"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -72,7 +72,7 @@
     "wasm-opt": "^1.4.0"
   },
   "dependencies": {
-    "@iota/iota-interaction-ts": "^0.13.0"
+    "@iota/iota-interaction-ts": "^0.14.0"
   },
   "peerDependencies": {
     "@iota/iota-sdk": "^1.14.0"

--- a/examples/07_transfer_dynamic_notarization.rs
+++ b/examples/07_transfer_dynamic_notarization.rs
@@ -15,8 +15,8 @@ async fn main() -> Result<()> {
     let notarization_client = get_funded_client().await?;
 
     // Generate random addresses for transfer recipients
-    let alice = IotaAddress::random_for_testing_only();
-    let bob = IotaAddress::random_for_testing_only();
+    let alice = IotaAddress::random();
+    let bob = IotaAddress::random();
 
     println!("Transfer recipients:");
     println!("Alice: {alice}");

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iota_interaction_ts.workspace = true
-tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
+tokio = { version = "1.52.2", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/notarization-rs/src/client/read_only.rs
+++ b/notarization-rs/src/client/read_only.rs
@@ -417,7 +417,7 @@ impl NotarizationClientReadOnly {
         let inspection_result = self
             .iota_client
             .read_api()
-            .dev_inspect_transaction_block(IotaAddress::ZERO, TransactionKind::programmable(tx), None, None, None)
+            .dev_inspect_transaction_block(IotaAddress::ZERO, TransactionKind::Programmable(tx), None, None, None)
             .await
             .map_err(|err| Error::UnexpectedApiResponse(format!("Failed to inspect transaction block: {err}")))?;
 

--- a/notarization-rs/src/core/move_utils.rs
+++ b/notarization-rs/src/core/move_utils.rs
@@ -4,10 +4,10 @@
 use std::str::FromStr;
 
 use iota_interaction::rpc_types::IotaObjectDataOptions;
-use iota_interaction::types::base_types::{ObjectID, ObjectRef};
+use iota_interaction::types::base_types::{ObjectID, ObjectRef, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
 use iota_interaction::types::transaction::{Argument, CallArg, SharedObjectRef};
-use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, base_types::TypeTag};
+use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION};
 use iota_interaction::{IotaClientTrait, OptionalSync};
 use product_common::core_client::CoreClientReadOnly;
 use serde::Serialize;

--- a/notarization-rs/src/core/move_utils.rs
+++ b/notarization-rs/src/core/move_utils.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use iota_interaction::rpc_types::IotaObjectDataOptions;
 use iota_interaction::types::base_types::{ObjectID, ObjectRef};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::{Argument, ObjectArg};
-use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, TypeTag};
+use iota_interaction::types::transaction::{Argument, CallArg, SharedObjectRef};
+use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, base_types::TypeTag};
 use iota_interaction::{IotaClientTrait, OptionalSync};
 use product_common::core_client::CoreClientReadOnly;
 use serde::Serialize;
@@ -16,11 +16,11 @@ use crate::error::Error;
 
 /// Adds a reference to the on-chain clock to `ptb`'s arguments.
 pub(crate) fn get_clock_ref(ptb: &mut Ptb) -> Argument {
-    ptb.obj(ObjectArg::SharedObject {
-        id: IOTA_CLOCK_OBJECT_ID,
+    ptb.obj(CallArg::Shared(SharedObjectRef {
+        object_id: IOTA_CLOCK_OBJECT_ID,
         initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
         mutable: false,
-    })
+    }))
     .expect("network has a singleton clock instantiated")
 }
 

--- a/notarization-rs/src/core/operations.rs
+++ b/notarization-rs/src/core/operations.rs
@@ -12,7 +12,7 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, Identifier};
+use iota_interaction::types::base_types::{Identifier, IotaAddress, ObjectID};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::{Argument, CallArg, ProgrammableTransaction};
 use iota_interaction::{OptionalSync, ident_str};

--- a/notarization-rs/src/core/operations.rs
+++ b/notarization-rs/src/core/operations.rs
@@ -12,10 +12,9 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use iota_interaction::types::Identifier;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::{IotaAddress, ObjectID, Identifier};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_interaction::types::transaction::{Argument, ObjectArg, ProgrammableTransaction};
+use iota_interaction::types::transaction::{Argument, CallArg, ProgrammableTransaction};
 use iota_interaction::{OptionalSync, ident_str};
 use product_common::core_client::CoreClientReadOnly;
 
@@ -65,7 +64,7 @@ impl NotarizationImpl {
             let notarization = move_utils::get_object_ref_by_id(client, &object_id).await?;
 
             vec![
-                ptb.obj(ObjectArg::ImmOrOwnedObject(notarization))
+                ptb.obj(CallArg::ImmutableOrOwned(notarization))
                     .map_err(|e| Error::InvalidArgument(format!("Failed to create object argument: {e}")))?,
             ]
         };
@@ -82,7 +81,7 @@ impl NotarizationImpl {
         // Build the move call
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!("notarization").into(),
+            ident_str!("notarization").as_str().into(),
             function,
             tag,
             args,
@@ -118,8 +117,8 @@ pub(crate) trait NotarizationOperations {
 
         ptb.programmable_move_call(
             package_id,
-            ident_str!("locked_notarization").into(),
-            ident_str!("create").into(),
+            ident_str!("locked_notarization").as_str().into(),
+            ident_str!("create").as_str().into(),
             vec![tag],
             vec![state_arg, immutable_description, updatable_metadata, delete_lock, clock],
         );
@@ -146,8 +145,8 @@ pub(crate) trait NotarizationOperations {
 
         ptb.programmable_move_call(
             package_id,
-            ident_str!("dynamic_notarization").into(),
-            ident_str!("create").into(),
+            ident_str!("dynamic_notarization").as_str().into(),
+            ident_str!("create").as_str().into(),
             vec![tag],
             vec![
                 state_arg,
@@ -320,15 +319,15 @@ pub(crate) trait NotarizationOperations {
 
         let notarization = move_utils::get_object_ref_by_id(client, &object_id).await?;
         let notarization = ptb
-            .obj(ObjectArg::ImmOrOwnedObject(notarization))
+            .obj(CallArg::ImmutableOrOwned(notarization))
             .map_err(|e| Error::InvalidArgument(format!("Failed to create notarization argument: {e}")))?;
 
         let clock = move_utils::get_clock_ref(&mut ptb);
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!("dynamic_notarization").into(),
-            ident_str!("transfer").into(),
+            ident_str!("dynamic_notarization").as_str().into(),
+            ident_str!("transfer").as_str().into(),
             tag,
             vec![notarization, recipient, clock],
         );

--- a/notarization-rs/src/core/transactions/create.rs
+++ b/notarization-rs/src/core/transactions/create.rs
@@ -242,11 +242,12 @@ pub(crate) async fn get_notarization_with_owner(
         .ok_or_else(|| Error::ObjectLookup("missing owner in data".to_string()))?;
 
     let address = match owner {
-        Owner::AddressOwner(address) => address,
-        Owner::ObjectOwner(address) => address,
-        Owner::Shared { .. } | Owner::Immutable => {
+        Owner::Address(address) => address,
+        Owner::Object(object_id) => *object_id.as_address(),
+        Owner::Shared(_) | Owner::Immutable => {
             unreachable!("object is not owned by an address");
         }
+        _ => unreachable!("non-exhaustive Owner variant"),
     };
 
     Ok((notarization, address))

--- a/notarization-rs/src/core/types/notarization.rs
+++ b/notarization-rs/src/core/types/notarization.rs
@@ -52,8 +52,12 @@ pub struct OnChainNotarization {
     /// The method of the notarization.
     pub method: NotarizationMethod,
     /// The owner of the notarization.
-    #[serde(skip)]
+    #[serde(skip, default = "iota_address_zero")]
     pub owner: IotaAddress,
+}
+
+fn iota_address_zero() -> IotaAddress {
+    IotaAddress::ZERO
 }
 
 #[cfg(feature = "irl")]

--- a/notarization-rs/src/core/types/state.rs
+++ b/notarization-rs/src/core/types/state.rs
@@ -43,10 +43,10 @@
 use std::str::FromStr;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::MOVE_STDLIB_PACKAGE_ID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::Argument;
-use iota_interaction::types::{MOVE_STDLIB_PACKAGE_ID, base_types::TypeTag};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::super::move_utils;

--- a/notarization-rs/src/core/types/state.rs
+++ b/notarization-rs/src/core/types/state.rs
@@ -46,7 +46,7 @@ use iota_interaction::ident_str;
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::Argument;
-use iota_interaction::types::{MOVE_STDLIB_PACKAGE_ID, TypeTag};
+use iota_interaction::types::{MOVE_STDLIB_PACKAGE_ID, base_types::TypeTag};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::super::move_utils;
@@ -261,8 +261,8 @@ fn state_from_bytes(
 
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("notarization").into(),
-        ident_str!("new_state_from_bytes").into(),
+        ident_str!("notarization").as_str().into(),
+        ident_str!("new_state_from_bytes").as_str().into(),
         vec![],
         vec![data, metadata],
     ))
@@ -280,8 +280,8 @@ fn state_from_string(
 
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("notarization").into(),
-        ident_str!("new_state_from_string").into(),
+        ident_str!("notarization").as_str().into(),
+        ident_str!("new_state_from_string").as_str().into(),
         vec![],
         vec![data, metadata],
     ))

--- a/notarization-rs/src/core/types/timelock.rs
+++ b/notarization-rs/src/core/types/timelock.rs
@@ -18,8 +18,7 @@
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use iota_interaction::types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
 use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
@@ -84,8 +83,8 @@ pub(super) fn new_unlock_at(ptb: &mut Ptb, unlock_time: u32, package_id: ObjectI
 
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("timelock").into(),
-        ident_str!("unlock_at").into(),
+        ident_str!("timelock").as_str().into(),
+        ident_str!("unlock_at").as_str().into(),
         vec![],
         vec![unlock_time, clock],
     ))
@@ -95,8 +94,8 @@ pub(super) fn new_unlock_at(ptb: &mut Ptb, unlock_time: u32, package_id: ObjectI
 pub(super) fn new_until_destroyed(ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("timelock").into(),
-        ident_str!("until_destroyed").into(),
+        ident_str!("timelock").as_str().into(),
+        ident_str!("until_destroyed").as_str().into(),
         vec![],
         vec![],
     ))
@@ -106,8 +105,8 @@ pub(super) fn new_until_destroyed(ptb: &mut Ptb, package_id: ObjectID) -> Result
 pub(super) fn new_none(ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("timelock").into(),
-        ident_str!("none").into(),
+        ident_str!("timelock").as_str().into(),
+        ident_str!("none").as_str().into(),
         vec![],
         vec![],
     ))

--- a/notarization-rs/tests/e2e/dynamic_notarization.rs
+++ b/notarization-rs/tests/e2e/dynamic_notarization.rs
@@ -82,7 +82,7 @@ async fn test_transfer_dynamic_notarization_client_with_transfer_lock_fails() ->
     let is_transfer_locked = test_client.is_transfer_locked(*notarization_id.object_id()).await?;
 
     assert!(is_transfer_locked);
-    let alice = IotaAddress::random_for_testing_only();
+    let alice = IotaAddress::random();
 
     let transfer_notarization = test_client
         .transfer_notarization(*notarization_id.object_id(), alice)
@@ -111,7 +111,7 @@ async fn test_transfer_dynamic_notarization_client_with_no_transfer_lock_works()
     let is_transfer_locked = test_client.is_transfer_locked(*notarization_id.object_id()).await?;
     assert!(!is_transfer_locked);
 
-    let alice = IotaAddress::random_for_testing_only();
+    let alice = IotaAddress::random();
 
     let transfer_notarization = test_client
         .transfer_notarization(*notarization_id.object_id(), alice)

--- a/notarization-rs/tests/e2e/locked_notarization.rs
+++ b/notarization-rs/tests/e2e/locked_notarization.rs
@@ -392,7 +392,7 @@ async fn test_locked_notarization_transfer_fails() -> anyhow::Result<()> {
         .output
         .id;
 
-    let alice = IotaAddress::random_for_testing_only();
+    let alice = IotaAddress::random();
 
     // Transfer should fail because locked notarizations have transfer_lock = UntilDestroyed
     let transfer_result = test_client


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [x] tokio version update to: 1.52.2
- [ ] fastcrypto version update to rev = "-"
- [x] notarization_wasm: new peerDep. version for @iota/iota-sdk: `"^1.14.0"`
- [x] notarization_wasm: new dependency version for @iota/iota-interaction-ts: `"^0.14.0"`
- [x] pin all product-core.git dependencies to `tag = "v0.8.18"`
- [x] pin all iota.git dependencies to `tag = "v1.23.2"`

IOTA 1.23.2 replaced several base-types formerly implemented in iota.git with types from the standalone Rust SDK (iota-rust-sdk.git). This caused several migrations in notarization_wasm and notarization_rs.

Summary of main changes:
  - `ident_str!(...).into()` occurrences:
    append `.as_str()` so the conversion goes via `From<&'static str>` for Identifier instead of the now-removed From<&IdentStr>.
  - Owner variant renamings: 
    - `AddressOwner`→ `Address`
    - `ObjectOwner` → `Object` (now carries `ObjectId`, dereffed via `as_address()`)
    - `Shared { .. }` → `Shared(_)`
    - add a catch-all arm since Owner is `#[non_exhaustive]`
  - `IotaAddress::random_for_testing_only()` → `IotaAddress::random()`
  - `TransactionKind::programmable(tx)` → `TransactionKind::Programmable(tx)`
  - `ObjectArg::SharedObject{...}` → `CallArg::Shared(SharedObjectRef {...})`
  - `ObjectArg::ImmOrOwnedObject(...)` → `CallArg::ImmutableOrOwned(...)`
  - `use iota_interaction::types::TypeTag` → `use iota_interaction::types::base_types::TypeTag`


## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67