### PR TITLE
Feat/audit trails dev new product name

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 docs-notarization = "doc -p notarization"
-docs-audit-trail = "doc -p audit_trail"
+docs-audit-trail = "doc -p audit_trails"

--- a/.claude/skills/sync-product-docs/SKILL.md
+++ b/.claude/skills/sync-product-docs/SKILL.md
@@ -254,7 +254,7 @@ is exactly how drift survives a commit that "already updated the docs".
 
 ## What "aligned" looks like — example
 
-For an entry `[audit_trail.locking.new]` (the `LockingConfig::new`
+For an entry `[audit_trails.locking.new]` (the `LockingConfig::new`
 constructor):
 
 - **Move** (`<move-sc-path>/locking.move`): "Create a new locking

--- a/.claude/skills/update-api-mapping/SKILL.md
+++ b/.claude/skills/update-api-mapping/SKILL.md
@@ -255,7 +255,7 @@ Expected behavior:
 3. Find e.g. an added `public fun pause_trail` in `audit_trail.move`, an
    added `PauseTrail` struct + `PauseTrail::new` in `audit-trail-rs/src`,
    and `WasmPauseTrail` with the usual two methods in the WASM crate.
-4. Propose a new `[audit_trail.main.pause_trail]` section with both arrays
+4. Propose a new `[audit_trails.main.pause_trail]` section with both arrays
    prefilled.
 5. Find e.g. that `delete_records_batch`'s removed Rust helper
    `TrailRecords::delete_batch_legacy` should be dropped from the existing

--- a/.github/workflows/wasm-publish.yml
+++ b/.github/workflows/wasm-publish.yml
@@ -145,4 +145,4 @@ jobs:
         if: ${{ github.event.inputs.package == 'audit-trail' }}
         shell: bash
         run: |
-          npm dist-tag add @iota/audit-trail@${{ github.event.inputs.retag-version }} ${{ github.event.inputs.retag-tag }}
+          npm dist-tag add @iota/audit-trails@${{ github.event.inputs.retag-version }} ${{ github.event.inputs.retag-tag }}

--- a/.github/workflows/wasm-retag-npm.yml
+++ b/.github/workflows/wasm-retag-npm.yml
@@ -42,4 +42,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_NOTARIZATION_TOKEN }}
         run: |
-          npm dist-tag add @iota/audit-trail@${{ github.event.inputs.version }} ${{ github.event.inputs.tag }}
+          npm dist-tag add @iota/audit-trails@${{ github.event.inputs.version }} ${{ github.event.inputs.tag }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ let cap = client
 
 Use `CapabilityIssueOptions { issued_to, valid_from_ms, valid_until_ms }` to restrict who may use the capability or set a validity window.
 
-**Key types** (from `audit_trail::core::types`): `Data`, `InitialRecord`, `ImmutableMetadata`, `LockingConfig`, `LockingWindow`, `TimeLock`, `Permission`, `PermissionSet`, `CapabilityIssueOptions`, `RoleTags`.
+**Key types** (from `audit_trails::core::types`): `Data`, `InitialRecord`, `ImmutableMetadata`, `LockingConfig`, `LockingWindow`, `TimeLock`, `Permission`, `PermissionSet`, `CapabilityIssueOptions`, `RoleTags`.
 
 ### Notarization example patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,23 +15,30 @@ IOTA Notarization enables creation of immutable, on-chain records for arbitrary 
     whatever suites into the context the best. In this stylguide `Toolkit` is used for referencing the term. Use "title case"
     allways for `Notarization Toolkit` (never use `Notarization toolkit` or `notarization toolkit`).
 - The IOTA Trust Framework consist of Trust Framework Products (TF products)
-- The Notarization Toolkit contains two TF products: **Single Notarization** and **Audit Trail**
-  - In the context of Notarization Toolkit documentation, Single Notarization and Audit Trail are called components
-  - In the context of IOTA Trust Framework documentation, Single Notarization and Audit Trail are called TF products
+- The Notarization Toolkit contains two TF products: **Single Notarization** and **Audit Trails**
+  - In the context of Notarization Toolkit documentation, Single Notarization and Audit Trails are called components
+  - In the context of IOTA Trust Framework documentation, Single Notarization and Audit Trails are called TF products
   - These rules also apply to future TF products in the Notarization Toolkit (i.e. "Proof of Inclusion")
-- The name of TF products resp. Notarization Toolkit components is allways a singular term
-  - Use capitalization (a.k.a. title case) for the words of a product name if the product is meant itself - examples `Audit Trail`, `Notarization`
-  - Use plural (i.e. `audit trails` or `notarizations`) only where multiple instances of the TF product are meant
+- Regarding usage of singular and plural in TF product resp. Notarization Toolkit component names:
+  - If the product is meant itself:
+    - Use the product name (i.e. `Audit Trails`, `Notarization`) with singular form - example: "Audit Trails is the best ..."
+    - Use capitalization (a.k.a. title case) - examples `Audit Trails`, `Notarization`
+  - If multiple instances of a product (typically equivalent to multiple on-chain objects) are meant:
+    - Use plural (i.e. `Using multiple audit trails facilitates ...` or `Avoid creating too much notarizations for ...`)
     - Use lower case for the plural form - except at the beginning of sentences and in markdown titles
-  - In situations where the TF product itself or the plural form can be addressed choose whatever fits best
-  - This rule - including capitalization aspects - only applies to TF products resp. Notarization Toolkit components using
-    plural for other entities like i.e. Notarization Methods (`Locked Notarization`, `Dynamic Notarization` - see below) is OK.
-  - Example `Audit Trail`:
-    - Do not use `Audit Trails` - always use `Audit Trail` to denote the product itself
-    - Use plural (i.e. `audit trails` or `Audit trails`) only where multiple instances of the TF product are meant - Examples:
-      - `A client for creating and managing audit trails on the IOTA blockchain`
-      - `Audit trails and their records are ...`
-      - `Audit trails provide ...` (could also be `Audit Trail provides ...`)
+  - If the TF product or multiple product instances could be meant: Prefer the TF product variant if possible. Only
+    use the plural variant where clearly more suitable.
+  - This rule - including the capitalization aspects - only applies to TF products (resp. Toolkit components). Using the
+    plural form with title case for other entities like i.e. Notarization Methods (`Locked Notarization`, `Dynamic Notarization` - see below) is OK.
+  - If onchain objects of the TF product are addressed:
+    - In source code documentation related to the TF product specific Move object type (i.e. `AuditTrail`, `Notarization`),
+      the type name followed by "object" resp. "objects" shall be used (examples: "To create a `Notarization` object use ...",
+      "`AuditTrail` objects can be batch deleted using ...").
+    - In less technical documentation, typically in the context of general descriptions of TF products or Notarization Toolkit components:
+      - the product name in singular of plural form shall be used (see above) without any extensions
+      - if the onchain object, equivalent to the product itself, is addressed, use either the Move object type based form (see above)
+        or the product name followed by "object" resp. "objects" (examples: "`Notarization` onchain objects facilitate ...",
+        "Audit Trails on-chain objects must be managed ... ") whatever is most suitable.
 - Regarding Single Notarization (Component/TF product):
   - Single Notarization provides two **Notarization Methods**: **Locked Notarization** and **Dynamic Notarization**
     - There might be additional Notarization Methods in future versions of Single Notarization (i.e. "Custom Notarization")

--- a/MOVE-DOC-STYLEGUIDE.md
+++ b/MOVE-DOC-STYLEGUIDE.md
@@ -172,7 +172,7 @@ For `Option<T>` returns, document both branches:
   abort list. The reader can follow the reference; we don't drift out of
   sync.
 - Inside the same module, omit the module prefix
-  (`` `add_record` `` rather than `` `audit_trail::main::add_record` ``).
+  (`` `add_record` `` rather than `` `audit_trails::main::add_record` ``).
 - Refer to permission variants by their bare enum name in backticks
   (`` `AddFoo` `` rather than `` `Permission::AddFoo` ``) — the
   context makes the type unambiguous and matches the permission constants
@@ -199,7 +199,7 @@ For `Option<T>` returns, document both branches:
   Field docs follow the same brevity rules as function summaries.
 - Error constants (`#[error] const E…`) carry the user-facing abort message;
   no separate doc comment is required when the message is self-explanatory.
-- Module-level docs (the `///` block above `module audit_trail::…;`) must
+- Module-level docs (the `///` block above `module audit_trails::…;`) must
   describe the module's purpose in one or two sentences.
 
 ## Don'ts

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The toolkit includes:
 
 - **Single Notarization**
   Use this for individual locked or dynamic notarizations of arbitrary data, documents, hashes, or latest-state records.
-- **Audit Trail**
+- **Audit Trails**
   Use this for structured record histories with sequential entries, role-based access control, locking, and tagging.
 
 Each toolkit component is available as:
@@ -50,31 +50,31 @@ Use **Single Notarization** when your main need is proving the existence, integr
 
 ### I want an audit trail
 
-Use **Audit Trail** when you need a structured record history with permissions, capabilities, tagging, and write or delete controls.
+Use **Audit Trails** when you need a structured record history with permissions, capabilities, tagging, and write or delete controls.
 
-- [Audit Trail Rust Package](./audit-trail-rs)
-- [Audit Trail Move Package](./audit-trail-move)
-- [Audit Trail Wasm Package](./bindings/wasm/audit_trail_wasm)
-- [Audit Trail examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
+- [Audit Trails Rust Package](./audit-trail-rs)
+- [Audit Trails Move Package](./audit-trail-move)
+- [Audit Trails Wasm Package](./bindings/wasm/audit_trail_wasm)
+- [Audit Trails examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
 
 ### I want the on-chain contracts
 
 - [Single Notarization Move](./notarization-move)
-- [Audit Trail Move](./audit-trail-move)
+- [Audit Trails Move](./audit-trail-move)
 
 ### I want to build an application
 
 - [Single Notarization Rust](./notarization-rs)
-- [Audit Trail Rust](./audit-trail-rs)
+- [Audit Trails Rust](./audit-trail-rs)
 - [Single Notarization Wasm](./bindings/wasm/notarization_wasm)
-- [Audit Trail Wasm](./bindings/wasm/audit_trail_wasm)
+- [Audit Trails Wasm](./bindings/wasm/audit_trail_wasm)
 
 ## Toolkit Components
 
 | Component           | Best for                                                                    | Move Package                               | Rust Package                           | Wasm Package                                             |
 | ------------------- | --------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------- | -------------------------------------------------------- |
 | Single Notarization | Individual locked or dynamic notarizations for documents, hashes, and state | [`notarization-move`](./notarization-move) | [`notarization-rs`](./notarization-rs) | [`notarization_wasm`](./bindings/wasm/notarization_wasm) |
-| Audit Trail         | Shared sequential records with roles, capabilities, tagging, and locking    | [`audit-trail-move`](./audit-trail-move)   | [`audit-trail-rs`](./audit-trail-rs)   | [`audit_trail_wasm`](./bindings/wasm/audit_trail_wasm)   |
+| Audit Trails        | Shared sequential records with roles, capabilities, tagging, and locking    | [`audit-trail-move`](./audit-trail-move)   | [`audit-trail-rs`](./audit-trail-rs)   | [`audit_trail_wasm`](./bindings/wasm/audit_trail_wasm)   |
 
 ### Which one should I use?
 
@@ -82,8 +82,8 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 | ------------------------------------------------------------------------- | ------------------- |
 | Locked proof object for arbitrary data                                    | Single Notarization |
 | Dynamic latest-state notarization flow                                    | Single Notarization |
-| Shared sequential records with roles, capabilities, and record tag policy | Audit Trail         |
-| Team or system audit log with governance and operational controls         | Audit Trail         |
+| Shared sequential records with roles, capabilities, and record tag policy | Audit Trails        |
+| Team or system audit log with governance and operational controls         | Audit Trails        |
 
 ## Documentation And Resources
 
@@ -95,12 +95,12 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 - [Single Notarization examples](./bindings/wasm/notarization_wasm/examples/README.md)
 - [IOTA Notarization Docs Portal](https://docs.iota.org/developer/iota-notarization)
 
-### Audit Trail
+### Audit Trails
 
-- [Audit Trail Rust Package README](./audit-trail-rs/README.md)
-- [Audit Trail Move Package README](./audit-trail-move/README.md)
-- [Audit Trail Wasm Package README](./bindings/wasm/audit_trail_wasm/README.md)
-- [Audit Trail examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
+- [Audit Trails Rust Package README](./audit-trail-rs/README.md)
+- [Audit Trails Move Package README](./audit-trail-move/README.md)
+- [Audit Trails Wasm Package README](./bindings/wasm/audit_trail_wasm/README.md)
+- [Audit Trails examples](./bindings/wasm/audit_trail_wasm/examples/README.md)
 
 ### Shared
 
@@ -111,7 +111,7 @@ Use **Audit Trail** when you need a structured record history with permissions, 
 [Foreign Function Interface (FFI)](https://en.wikipedia.org/wiki/Foreign_function_interface) bindings available in this repository:
 
 - [Web Assembly for Single Notarization](./bindings/wasm/notarization_wasm)
-- [Web Assembly for Audit Trail](./bindings/wasm/audit_trail_wasm)
+- [Web Assembly for Audit Trails](./bindings/wasm/audit_trail_wasm)
 
 ## Contributing
 

--- a/audit-trail-move/Move.toml
+++ b/audit-trail-move/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "IotaAuditTrail"
+name = "IotaAuditTrails"
 edition = "2024.beta"
 
 [dependencies]

--- a/audit-trail-move/Move.toml
+++ b/audit-trail-move/Move.toml
@@ -6,4 +6,4 @@ edition = "2024.beta"
 TfComponents = { git = "https://github.com/iotaledger/product-core.git", subdir = "components_move", rev = "v0.8.19" }
 
 [addresses]
-audit_trail = "0x0"
+audit_trails = "0x0"

--- a/audit-trail-move/README.md
+++ b/audit-trail-move/README.md
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-`audit-trail-move` is the on-chain Move package behind IOTA Audit Trails.
+`IotaAuditTrails` is the on-chain Move package behind IOTA Audit Trails.
 
 It defines the shared `AuditTrail` object and the supporting types needed for:
 

--- a/audit-trail-move/README.md
+++ b/audit-trail-move/README.md
@@ -35,15 +35,15 @@ The package depends on `TfComponents` for reusable capability, role-map, and tim
 
 ## Modules
 
-- `audit_trail::main`
+- `audit_trails::main`
   Core shared object, events, trail lifecycle, record mutation, metadata updates, roles, and capabilities.
-- `audit_trail::record`
+- `audit_trails::record`
   Record payloads, initial records, and correction metadata.
-- `audit_trail::locking`
+- `audit_trails::locking`
   Locking configuration and lock evaluation helpers.
-- `audit_trail::permission`
+- `audit_trails::permission`
   Permission constructors and admin permission presets.
-- `audit_trail::record_tags`
+- `audit_trails::record_tags`
   Tag registry and role tag helpers.
 
 ## Development And Testing

--- a/audit-trail-move/README.md
+++ b/audit-trail-move/README.md
@@ -16,11 +16,11 @@
 
 ---
 
-# IOTA Audit Trail Move Package
+# IOTA Audit Trails Move Package
 
 ## Introduction
 
-`audit-trail-move` is the on-chain Move package behind IOTA Audit Trail.
+`audit-trail-move` is the on-chain Move package behind IOTA Audit Trails.
 
 It defines the shared `AuditTrail` object and the supporting types needed for:
 
@@ -81,7 +81,7 @@ The package history files [`Move.lock`](./Move.lock) and [`Move.history.json`](.
 
 ## Contributing
 
-We would love to have you help us with the development of IOTA Audit Trail. Each and every contribution is greatly valued.
+We would love to have you help us with the development of IOTA Audit Trails. Each and every contribution is greatly valued.
 
 Please review the [contribution](https://docs.iota.org/developer/iota-notarization/contribute) sections in the [IOTA Docs Portal](https://docs.iota.org/developer/iota-notarization/).
 

--- a/audit-trail-move/api_mapping.toml
+++ b/audit-trail-move/api_mapping.toml
@@ -30,10 +30,10 @@
 # the `update-api-mapping` and `sync-product-docs` skills under `.claude/skills/`.
 
 # =============================================================================
-# Module: audit_trail::main (audit-trail-move/sources/audit_trail.move)
+# Module: audit_trails::main (audit-trail-move/sources/audit_trail.move)
 # =============================================================================
 
-[audit_trail.main.ImmutableMetadata]
+[audit_trails.main.ImmutableMetadata]
 rust = [
   "ImmutableMetadata",
   "ImmutableMetadata::new",
@@ -44,7 +44,7 @@ wasm = [
   "WasmImmutableMetadata",
 ]
 
-[audit_trail.main.AuditTrail]
+[audit_trails.main.AuditTrail]
 rust = [
   "OnChainAuditTrail",
   "AuditTrailHandle",
@@ -77,7 +77,7 @@ wasm = [
   "WasmAuditTrailHandle::tags",
 ]
 
-[audit_trail.main.AuditTrailCreated]
+[audit_trails.main.AuditTrailCreated]
 rust = [
   "AuditTrailCreated",
   "TrailCreated",
@@ -87,7 +87,7 @@ wasm = [
   "WasmAuditTrailCreated",
 ]
 
-[audit_trail.main.AuditTrailDeleted]
+[audit_trails.main.AuditTrailDeleted]
 rust = [
   "AuditTrailDeleted",
 ]
@@ -95,7 +95,7 @@ wasm = [
   "WasmAuditTrailDeleted",
 ]
 
-[audit_trail.main.RecordAdded]
+[audit_trails.main.RecordAdded]
 rust = [
   "RecordAdded",
 ]
@@ -103,7 +103,7 @@ wasm = [
   "WasmRecordAdded",
 ]
 
-[audit_trail.main.RecordDeleted]
+[audit_trails.main.RecordDeleted]
 rust = [
   "RecordDeleted",
 ]
@@ -111,7 +111,7 @@ wasm = [
   "WasmRecordDeleted",
 ]
 
-[audit_trail.main.RevokedCapabilitiesCleanedUp]
+[audit_trails.main.RevokedCapabilitiesCleanedUp]
 rust = [
   "RevokedCapabilitiesCleanedUp",
 ]
@@ -119,7 +119,7 @@ wasm = [
   "WasmRevokedCapabilitiesCleanedUp",
 ]
 
-[audit_trail.main.CapabilityIssuedReceipt]
+[audit_trails.main.CapabilityIssuedReceipt]
 rust = [
   "CapabilityIssued",
 ]
@@ -127,7 +127,7 @@ wasm = [
   "WasmCapabilityIssued",
 ]
 
-[audit_trail.main.new_trail_metadata]
+[audit_trails.main.new_trail_metadata]
 rust = [
   "ImmutableMetadata::new",
   "ImmutableMetadata::to_ptb",
@@ -139,7 +139,7 @@ wasm = [
   "WasmAuditTrailBuilder::with_trail_metadata",
 ]
 
-[audit_trail.main.create]
+[audit_trails.main.create]
 rust = [
   "AuditTrailBuilder",
   "AuditTrailBuilder::with_initial_record",
@@ -176,7 +176,7 @@ wasm = [
   "WasmAuditTrailClient::trail",
 ]
 
-[audit_trail.main.initial_admin_role_name]
+[audit_trails.main.initial_admin_role_name]
 rust = [
   "RoleMap.initial_admin_role_name",
 ]
@@ -184,7 +184,7 @@ wasm = [
   "WasmRoleMap.initial_admin_role_name",
 ]
 
-[audit_trail.main.migrate]
+[audit_trails.main.migrate]
 rust = [
   "Migrate",
   "Migrate::new",
@@ -197,7 +197,7 @@ wasm = [
   "WasmAuditTrailHandle::migrate",
 ]
 
-[audit_trail.main.add_record]
+[audit_trails.main.add_record]
 rust = [
   "AddRecord",
   "AddRecord::new",
@@ -210,7 +210,7 @@ wasm = [
   "WasmTrailRecords::add",
 ]
 
-[audit_trail.main.delete_record]
+[audit_trails.main.delete_record]
 rust = [
   "DeleteRecord",
   "DeleteRecord::new",
@@ -223,7 +223,7 @@ wasm = [
   "WasmTrailRecords::delete",
 ]
 
-[audit_trail.main.delete_records_batch]
+[audit_trails.main.delete_records_batch]
 rust = [
   "DeleteRecordsBatch",
   "DeleteRecordsBatch::new",
@@ -236,7 +236,7 @@ wasm = [
   "WasmTrailRecords::delete_batch",
 ]
 
-[audit_trail.main.delete_audit_trail]
+[audit_trails.main.delete_audit_trail]
 rust = [
   "DeleteAuditTrail",
   "DeleteAuditTrail::new",
@@ -249,7 +249,7 @@ wasm = [
   "WasmAuditTrailHandle::delete_audit_trail",
 ]
 
-[audit_trail.main.is_record_locked]
+[audit_trails.main.is_record_locked]
 rust = [
   "TrailLocking::is_record_locked",
 ]
@@ -257,7 +257,7 @@ wasm = [
   "WasmTrailLocking::is_record_locked",
 ]
 
-[audit_trail.main.update_locking_config]
+[audit_trails.main.update_locking_config]
 rust = [
   "UpdateLockingConfig",
   "UpdateLockingConfig::new",
@@ -270,7 +270,7 @@ wasm = [
   "WasmTrailLocking::update",
 ]
 
-[audit_trail.main.update_delete_record_window]
+[audit_trails.main.update_delete_record_window]
 rust = [
   "UpdateDeleteRecordWindow",
   "UpdateDeleteRecordWindow::new",
@@ -283,7 +283,7 @@ wasm = [
   "WasmTrailLocking::update_delete_record_window",
 ]
 
-[audit_trail.main.update_delete_trail_lock]
+[audit_trails.main.update_delete_trail_lock]
 rust = [
   "UpdateDeleteTrailLock",
   "UpdateDeleteTrailLock::new",
@@ -296,7 +296,7 @@ wasm = [
   "WasmTrailLocking::update_delete_trail_lock",
 ]
 
-[audit_trail.main.update_write_lock]
+[audit_trails.main.update_write_lock]
 rust = [
   "UpdateWriteLock",
   "UpdateWriteLock::new",
@@ -309,7 +309,7 @@ wasm = [
   "WasmTrailLocking::update_write_lock",
 ]
 
-[audit_trail.main.update_metadata]
+[audit_trails.main.update_metadata]
 rust = [
   "UpdateMetadata",
   "UpdateMetadata::new",
@@ -322,7 +322,7 @@ wasm = [
   "WasmAuditTrailHandle::update_metadata",
 ]
 
-[audit_trail.main.add_record_tag]
+[audit_trails.main.add_record_tag]
 rust = [
   "AddRecordTag",
   "AddRecordTag::new",
@@ -335,7 +335,7 @@ wasm = [
   "WasmTrailTags::add",
 ]
 
-[audit_trail.main.remove_record_tag]
+[audit_trails.main.remove_record_tag]
 rust = [
   "RemoveRecordTag",
   "RemoveRecordTag::new",
@@ -348,7 +348,7 @@ wasm = [
   "WasmTrailTags::remove",
 ]
 
-[audit_trail.main.create_role]
+[audit_trails.main.create_role]
 rust = [
   "CreateRole",
   "CreateRole::new",
@@ -363,7 +363,7 @@ wasm = [
   "WasmTrailAccess::for_role",
 ]
 
-[audit_trail.main.update_role_permissions]
+[audit_trails.main.update_role_permissions]
 rust = [
   "UpdateRole",
   "UpdateRole::new",
@@ -376,7 +376,7 @@ wasm = [
   "WasmRoleHandle::update_permissions",
 ]
 
-[audit_trail.main.delete_role]
+[audit_trails.main.delete_role]
 rust = [
   "DeleteRole",
   "DeleteRole::new",
@@ -389,7 +389,7 @@ wasm = [
   "WasmRoleHandle::delete",
 ]
 
-[audit_trail.main.new_capability]
+[audit_trails.main.new_capability]
 rust = [
   "IssueCapability",
   "IssueCapability::new",
@@ -406,7 +406,7 @@ wasm = [
   "WasmCapabilityIssued",
 ]
 
-[audit_trail.main.revoke_capability]
+[audit_trails.main.revoke_capability]
 rust = [
   "RevokeCapability",
   "RevokeCapability::new",
@@ -421,7 +421,7 @@ wasm = [
   "WasmCapabilityRevoked",
 ]
 
-[audit_trail.main.destroy_capability]
+[audit_trails.main.destroy_capability]
 rust = [
   "DestroyCapability",
   "DestroyCapability::new",
@@ -436,7 +436,7 @@ wasm = [
   "WasmCapabilityDestroyed",
 ]
 
-[audit_trail.main.destroy_initial_admin_capability]
+[audit_trails.main.destroy_initial_admin_capability]
 rust = [
   "DestroyInitialAdminCapability",
   "DestroyInitialAdminCapability::new",
@@ -449,7 +449,7 @@ wasm = [
   "WasmTrailAccess::destroy_initial_admin_capability",
 ]
 
-[audit_trail.main.revoke_initial_admin_capability]
+[audit_trails.main.revoke_initial_admin_capability]
 rust = [
   "RevokeInitialAdminCapability",
   "RevokeInitialAdminCapability::new",
@@ -462,7 +462,7 @@ wasm = [
   "WasmTrailAccess::revoke_initial_admin_capability",
 ]
 
-[audit_trail.main.cleanup_revoked_capabilities]
+[audit_trails.main.cleanup_revoked_capabilities]
 rust = [
   "CleanupRevokedCapabilities",
   "CleanupRevokedCapabilities::new",
@@ -475,7 +475,7 @@ wasm = [
   "WasmTrailAccess::cleanup_revoked_capabilities",
 ]
 
-[audit_trail.main.record_count]
+[audit_trails.main.record_count]
 rust = [
   "TrailRecords::record_count",
 ]
@@ -483,7 +483,7 @@ wasm = [
   "WasmTrailRecords::record_count",
 ]
 
-[audit_trail.main.sequence_number]
+[audit_trails.main.sequence_number]
 rust = [
   "OnChainAuditTrail.sequence_number",
 ]
@@ -491,7 +491,7 @@ wasm = [
   "WasmOnChainAuditTrail::sequence_number",
 ]
 
-[audit_trail.main.creator]
+[audit_trails.main.creator]
 rust = [
   "OnChainAuditTrail.creator",
 ]
@@ -499,7 +499,7 @@ wasm = [
   "WasmOnChainAuditTrail::creator",
 ]
 
-[audit_trail.main.created_at]
+[audit_trails.main.created_at]
 rust = [
   "OnChainAuditTrail.created_at",
 ]
@@ -507,7 +507,7 @@ wasm = [
   "WasmOnChainAuditTrail::created_at",
 ]
 
-[audit_trail.main.id]
+[audit_trails.main.id]
 rust = [
   "OnChainAuditTrail.id",
 ]
@@ -515,7 +515,7 @@ wasm = [
   "WasmOnChainAuditTrail::id",
 ]
 
-[audit_trail.main.name]
+[audit_trails.main.name]
 rust = [
   "OnChainAuditTrail.immutable_metadata",
   "ImmutableMetadata.name",
@@ -525,7 +525,7 @@ wasm = [
   "WasmImmutableMetadata.name",
 ]
 
-[audit_trail.main.description]
+[audit_trails.main.description]
 rust = [
   "OnChainAuditTrail.immutable_metadata",
   "ImmutableMetadata.description",
@@ -535,7 +535,7 @@ wasm = [
   "WasmImmutableMetadata.description",
 ]
 
-[audit_trail.main.metadata]
+[audit_trails.main.metadata]
 rust = [
   "OnChainAuditTrail.updatable_metadata",
 ]
@@ -543,7 +543,7 @@ wasm = [
   "WasmOnChainAuditTrail::updatable_metadata",
 ]
 
-[audit_trail.main.locking_config]
+[audit_trails.main.locking_config]
 rust = [
   "OnChainAuditTrail.locking_config",
   "TrailLocking",
@@ -553,7 +553,7 @@ wasm = [
   "WasmTrailLocking",
 ]
 
-[audit_trail.main.tags]
+[audit_trails.main.tags]
 rust = [
   "OnChainAuditTrail.tags",
   "TagRegistry",
@@ -564,7 +564,7 @@ wasm = [
   "WasmRecordTagEntry",
 ]
 
-[audit_trail.main.is_empty]
+[audit_trails.main.is_empty]
 rust = [
   "OnChainAuditTrail.records",
   "TrailRecords::record_count",
@@ -573,7 +573,7 @@ wasm = [
   "WasmTrailRecords::record_count",
 ]
 
-[audit_trail.main.first_sequence]
+[audit_trails.main.first_sequence]
 rust = [
   "OnChainAuditTrail.records",
 ]
@@ -581,7 +581,7 @@ wasm = [
   "WasmLinkedTable.head",
 ]
 
-[audit_trail.main.last_sequence]
+[audit_trails.main.last_sequence]
 rust = [
   "OnChainAuditTrail.records",
 ]
@@ -589,7 +589,7 @@ wasm = [
   "WasmLinkedTable.tail",
 ]
 
-[audit_trail.main.get_record]
+[audit_trails.main.get_record]
 rust = [
   "TrailRecords::get",
 ]
@@ -597,7 +597,7 @@ wasm = [
   "WasmTrailRecords::get",
 ]
 
-[audit_trail.main.has_record]
+[audit_trails.main.has_record]
 rust = [
   "TrailRecords::get",
 ]
@@ -605,7 +605,7 @@ wasm = [
   "WasmTrailRecords::get",
 ]
 
-[audit_trail.main.records]
+[audit_trails.main.records]
 rust = [
   "OnChainAuditTrail.records",
   "TrailRecords",
@@ -624,7 +624,7 @@ wasm = [
   "WasmPaginatedRecord",
 ]
 
-[audit_trail.main.access]
+[audit_trails.main.access]
 rust = [
   "OnChainAuditTrail.roles",
   "RoleMap",
@@ -638,7 +638,7 @@ wasm = [
   "WasmAuditTrailHandle::access",
 ]
 
-[audit_trail.main.access_mut]
+[audit_trails.main.access_mut]
 rust = [
   "TrailAccess",
 ]
@@ -647,10 +647,10 @@ wasm = [
 ]
 
 # =============================================================================
-# Module: audit_trail::locking (audit-trail-move/sources/locking.move)
+# Module: audit_trails::locking (audit-trail-move/sources/locking.move)
 # =============================================================================
 
-[audit_trail.locking.LockingWindow]
+[audit_trails.locking.LockingWindow]
 rust = [
   "LockingWindow",
   "LockingWindow::to_ptb",
@@ -661,7 +661,7 @@ wasm = [
   "WasmLockingWindowType",
 ]
 
-[audit_trail.locking.LockingConfig]
+[audit_trails.locking.LockingConfig]
 rust = [
   "LockingConfig",
   "LockingConfig::to_ptb",
@@ -673,7 +673,7 @@ wasm = [
   "WasmLockingConfig::new",
 ]
 
-[audit_trail.locking.window_none]
+[audit_trails.locking.window_none]
 rust = [
   "LockingWindow::None",
 ]
@@ -681,7 +681,7 @@ wasm = [
   "WasmLockingWindow::with_none",
 ]
 
-[audit_trail.locking.window_time_based]
+[audit_trails.locking.window_time_based]
 rust = [
   "LockingWindow::TimeBased",
 ]
@@ -689,7 +689,7 @@ wasm = [
   "WasmLockingWindow::with_time_based",
 ]
 
-[audit_trail.locking.window_count_based]
+[audit_trails.locking.window_count_based]
 rust = [
   "LockingWindow::CountBased",
   "LockingWindow::validate",
@@ -698,7 +698,7 @@ wasm = [
   "WasmLockingWindow::with_count_based",
 ]
 
-[audit_trail.locking.new]
+[audit_trails.locking.new]
 rust = [
   "LockingConfig",
   "LockingConfig::to_ptb",
@@ -709,19 +709,19 @@ wasm = [
   "WasmLockingConfig::new",
 ]
 
-[audit_trail.locking.is_delete_trail_locked]
+[audit_trails.locking.is_delete_trail_locked]
 rust = []
 wasm = []
 
-[audit_trail.locking.is_write_locked]
+[audit_trails.locking.is_write_locked]
 rust = []
 wasm = []
 
 # =============================================================================
-# Module: audit_trail::permission (audit-trail-move/sources/permission.move)
+# Module: audit_trails::permission (audit-trail-move/sources/permission.move)
 # =============================================================================
 
-[audit_trail.permission.Permission]
+[audit_trails.permission.Permission]
 rust = [
   "Permission",
   "Permission::function_name",
@@ -732,7 +732,7 @@ wasm = [
   "WasmPermission",
 ]
 
-[audit_trail.permission.empty]
+[audit_trails.permission.empty]
 rust = [
   "PermissionSet",
   "PermissionSet::default",
@@ -741,7 +741,7 @@ wasm = [
   "WasmPermissionSet::new",
 ]
 
-[audit_trail.permission.add]
+[audit_trails.permission.add]
 rust = [
   "PermissionSet.permissions",
 ]
@@ -749,7 +749,7 @@ wasm = [
   "WasmPermissionSet.permissions",
 ]
 
-[audit_trail.permission.from_vec]
+[audit_trails.permission.from_vec]
 rust = [
   "PermissionSet",
   "PermissionSet::to_move_vec",
@@ -759,7 +759,7 @@ wasm = [
   "WasmPermissionSet::new",
 ]
 
-[audit_trail.permission.has_permission]
+[audit_trails.permission.has_permission]
 rust = [
   "PermissionSet.permissions",
 ]
@@ -767,7 +767,7 @@ wasm = [
   "WasmPermissionSet.permissions",
 ]
 
-[audit_trail.permission.admin_permissions]
+[audit_trails.permission.admin_permissions]
 rust = [
   "PermissionSet::admin_permissions",
 ]
@@ -775,7 +775,7 @@ wasm = [
   "WasmPermissionSet::admin_permissions",
 ]
 
-[audit_trail.permission.record_admin_permissions]
+[audit_trails.permission.record_admin_permissions]
 rust = [
   "PermissionSet::record_admin_permissions",
 ]
@@ -783,7 +783,7 @@ wasm = [
   "WasmPermissionSet::record_admin_permissions",
 ]
 
-[audit_trail.permission.locking_admin_permissions]
+[audit_trails.permission.locking_admin_permissions]
 rust = [
   "PermissionSet::locking_admin_permissions",
 ]
@@ -791,7 +791,7 @@ wasm = [
   "WasmPermissionSet::locking_admin_permissions",
 ]
 
-[audit_trail.permission.role_admin_permissions]
+[audit_trails.permission.role_admin_permissions]
 rust = [
   "PermissionSet::role_admin_permissions",
   "RoleAdminPermissions",
@@ -801,7 +801,7 @@ wasm = [
   "WasmRoleAdminPermissions",
 ]
 
-[audit_trail.permission.tag_admin_permissions]
+[audit_trails.permission.tag_admin_permissions]
 rust = [
   "PermissionSet::tag_admin_permissions",
 ]
@@ -809,7 +809,7 @@ wasm = [
   "WasmPermissionSet::tag_admin_permissions",
 ]
 
-[audit_trail.permission.cap_admin_permissions]
+[audit_trails.permission.cap_admin_permissions]
 rust = [
   "PermissionSet::cap_admin_permissions",
   "CapabilityAdminPermissions",
@@ -819,7 +819,7 @@ wasm = [
   "WasmCapabilityAdminPermissions",
 ]
 
-[audit_trail.permission.metadata_admin_permissions]
+[audit_trails.permission.metadata_admin_permissions]
 rust = [
   "PermissionSet::metadata_admin_permissions",
 ]
@@ -827,7 +827,7 @@ wasm = [
   "WasmPermissionSet::metadata_admin_permissions",
 ]
 
-[audit_trail.permission.delete_audit_trail]
+[audit_trails.permission.delete_audit_trail]
 rust = [
   "Permission::DeleteAuditTrail",
 ]
@@ -835,7 +835,7 @@ wasm = [
   "WasmPermission::DeleteAuditTrail",
 ]
 
-[audit_trail.permission.delete_all_records]
+[audit_trails.permission.delete_all_records]
 rust = [
   "Permission::DeleteAllRecords",
 ]
@@ -843,7 +843,7 @@ wasm = [
   "WasmPermission::DeleteAllRecords",
 ]
 
-[audit_trail.permission.add_record]
+[audit_trails.permission.add_record]
 rust = [
   "Permission::AddRecord",
 ]
@@ -851,7 +851,7 @@ wasm = [
   "WasmPermission::AddRecord",
 ]
 
-[audit_trail.permission.delete_record]
+[audit_trails.permission.delete_record]
 rust = [
   "Permission::DeleteRecord",
 ]
@@ -859,7 +859,7 @@ wasm = [
   "WasmPermission::DeleteRecord",
 ]
 
-[audit_trail.permission.correct_record]
+[audit_trails.permission.correct_record]
 rust = [
   "Permission::CorrectRecord",
 ]
@@ -867,7 +867,7 @@ wasm = [
   "WasmPermission::CorrectRecord",
 ]
 
-[audit_trail.permission.update_locking_config]
+[audit_trails.permission.update_locking_config]
 rust = [
   "Permission::UpdateLockingConfig",
 ]
@@ -875,7 +875,7 @@ wasm = [
   "WasmPermission::UpdateLockingConfig",
 ]
 
-[audit_trail.permission.update_locking_config_for_delete_record]
+[audit_trails.permission.update_locking_config_for_delete_record]
 rust = [
   "Permission::UpdateLockingConfigForDeleteRecord",
 ]
@@ -883,7 +883,7 @@ wasm = [
   "WasmPermission::UpdateLockingConfigForDeleteRecord",
 ]
 
-[audit_trail.permission.update_locking_config_for_delete_trail]
+[audit_trails.permission.update_locking_config_for_delete_trail]
 rust = [
   "Permission::UpdateLockingConfigForDeleteTrail",
 ]
@@ -891,7 +891,7 @@ wasm = [
   "WasmPermission::UpdateLockingConfigForDeleteTrail",
 ]
 
-[audit_trail.permission.update_locking_config_for_write]
+[audit_trails.permission.update_locking_config_for_write]
 rust = [
   "Permission::UpdateLockingConfigForWrite",
 ]
@@ -899,7 +899,7 @@ wasm = [
   "WasmPermission::UpdateLockingConfigForWrite",
 ]
 
-[audit_trail.permission.add_record_tags]
+[audit_trails.permission.add_record_tags]
 rust = [
   "Permission::AddRecordTags",
 ]
@@ -907,7 +907,7 @@ wasm = [
   "WasmPermission::AddRecordTags",
 ]
 
-[audit_trail.permission.delete_record_tags]
+[audit_trails.permission.delete_record_tags]
 rust = [
   "Permission::DeleteRecordTags",
 ]
@@ -915,7 +915,7 @@ wasm = [
   "WasmPermission::DeleteRecordTags",
 ]
 
-[audit_trail.permission.add_roles]
+[audit_trails.permission.add_roles]
 rust = [
   "Permission::AddRoles",
 ]
@@ -923,7 +923,7 @@ wasm = [
   "WasmPermission::AddRoles",
 ]
 
-[audit_trail.permission.update_roles]
+[audit_trails.permission.update_roles]
 rust = [
   "Permission::UpdateRoles",
 ]
@@ -931,7 +931,7 @@ wasm = [
   "WasmPermission::UpdateRoles",
 ]
 
-[audit_trail.permission.delete_roles]
+[audit_trails.permission.delete_roles]
 rust = [
   "Permission::DeleteRoles",
 ]
@@ -939,7 +939,7 @@ wasm = [
   "WasmPermission::DeleteRoles",
 ]
 
-[audit_trail.permission.add_capabilities]
+[audit_trails.permission.add_capabilities]
 rust = [
   "Permission::AddCapabilities",
 ]
@@ -947,7 +947,7 @@ wasm = [
   "WasmPermission::AddCapabilities",
 ]
 
-[audit_trail.permission.revoke_capabilities]
+[audit_trails.permission.revoke_capabilities]
 rust = [
   "Permission::RevokeCapabilities",
 ]
@@ -955,7 +955,7 @@ wasm = [
   "WasmPermission::RevokeCapabilities",
 ]
 
-[audit_trail.permission.update_metadata]
+[audit_trails.permission.update_metadata]
 rust = [
   "Permission::UpdateMetadata",
 ]
@@ -963,7 +963,7 @@ wasm = [
   "WasmPermission::UpdateMetadata",
 ]
 
-[audit_trail.permission.delete_metadata]
+[audit_trails.permission.delete_metadata]
 rust = [
   "Permission::DeleteMetadata",
 ]
@@ -971,7 +971,7 @@ wasm = [
   "WasmPermission::DeleteMetadata",
 ]
 
-[audit_trail.permission.migrate_audit_trail]
+[audit_trails.permission.migrate_audit_trail]
 rust = [
   "Permission::Migrate",
 ]
@@ -980,10 +980,10 @@ wasm = [
 ]
 
 # =============================================================================
-# Module: audit_trail::record (audit-trail-move/sources/record.move)
+# Module: audit_trails::record (audit-trail-move/sources/record.move)
 # =============================================================================
 
-[audit_trail.record.Data]
+[audit_trails.record.Data]
 rust = [
   "Data",
   "Data::tag",
@@ -999,7 +999,7 @@ wasm = [
   "WasmData::to_bytes",
 ]
 
-[audit_trail.record.new_bytes]
+[audit_trails.record.new_bytes]
 rust = [
   "Data::bytes",
   "Data::Bytes",
@@ -1008,7 +1008,7 @@ wasm = [
   "WasmData::from_bytes",
 ]
 
-[audit_trail.record.new_text]
+[audit_trails.record.new_text]
 rust = [
   "Data::text",
   "Data::Text",
@@ -1017,7 +1017,7 @@ wasm = [
   "WasmData::from_string",
 ]
 
-[audit_trail.record.bytes]
+[audit_trails.record.bytes]
 rust = [
   "Data::as_bytes",
   "Data::Bytes",
@@ -1026,7 +1026,7 @@ wasm = [
   "WasmData::to_bytes",
 ]
 
-[audit_trail.record.text]
+[audit_trails.record.text]
 rust = [
   "Data::as_text",
   "Data::Text",
@@ -1035,7 +1035,7 @@ wasm = [
   "WasmData::to_string",
 ]
 
-[audit_trail.record.Record]
+[audit_trails.record.Record]
 rust = [
   "Record",
 ]
@@ -1043,7 +1043,7 @@ wasm = [
   "WasmRecord",
 ]
 
-[audit_trail.record.InitialRecord]
+[audit_trails.record.InitialRecord]
 rust = [
   "InitialRecord",
   "InitialRecord::new",
@@ -1057,7 +1057,7 @@ wasm = [
   "WasmAuditTrailBuilder::with_initial_record_bytes",
 ]
 
-[audit_trail.record.new_initial_record]
+[audit_trails.record.new_initial_record]
 rust = [
   "InitialRecord::new",
   "InitialRecord::into_ptb",
@@ -1069,7 +1069,7 @@ wasm = [
   "WasmAuditTrailBuilder::with_initial_record_bytes",
 ]
 
-[audit_trail.record.data]
+[audit_trails.record.data]
 rust = [
   "Record.data",
 ]
@@ -1077,7 +1077,7 @@ wasm = [
   "WasmRecord.data",
 ]
 
-[audit_trail.record.metadata]
+[audit_trails.record.metadata]
 rust = [
   "Record.metadata",
 ]
@@ -1085,7 +1085,7 @@ wasm = [
   "WasmRecord.metadata",
 ]
 
-[audit_trail.record.tag]
+[audit_trails.record.tag]
 rust = [
   "Record.tag",
 ]
@@ -1093,7 +1093,7 @@ wasm = [
   "WasmRecord.tag",
 ]
 
-[audit_trail.record.sequence_number]
+[audit_trails.record.sequence_number]
 rust = [
   "Record.sequence_number",
 ]
@@ -1101,7 +1101,7 @@ wasm = [
   "WasmRecord.sequence_number",
 ]
 
-[audit_trail.record.added_by]
+[audit_trails.record.added_by]
 rust = [
   "Record.added_by",
 ]
@@ -1109,7 +1109,7 @@ wasm = [
   "WasmRecord.added_by",
 ]
 
-[audit_trail.record.added_at]
+[audit_trails.record.added_at]
 rust = [
   "Record.added_at",
 ]
@@ -1117,7 +1117,7 @@ wasm = [
   "WasmRecord.added_at",
 ]
 
-[audit_trail.record.correction]
+[audit_trails.record.correction]
 rust = [
   "Record.correction",
 ]
@@ -1125,7 +1125,7 @@ wasm = [
   "WasmRecord.correction",
 ]
 
-[audit_trail.record.RecordCorrection]
+[audit_trails.record.RecordCorrection]
 rust = [
   "RecordCorrection",
   "RecordCorrection::with_replaces",
@@ -1136,7 +1136,7 @@ wasm = [
   "WasmRecordCorrection",
 ]
 
-[audit_trail.record.empty]
+[audit_trails.record.empty]
 rust = [
   "RecordCorrection::default",
 ]
@@ -1144,7 +1144,7 @@ wasm = [
   "WasmRecordCorrection",
 ]
 
-[audit_trail.record.with_replaces]
+[audit_trails.record.with_replaces]
 rust = [
   "RecordCorrection::with_replaces",
 ]
@@ -1152,7 +1152,7 @@ wasm = [
   "WasmRecordCorrection.replaces",
 ]
 
-[audit_trail.record.replaces]
+[audit_trails.record.replaces]
 rust = [
   "RecordCorrection.replaces",
 ]
@@ -1160,7 +1160,7 @@ wasm = [
   "WasmRecordCorrection.replaces",
 ]
 
-[audit_trail.record.is_replaced_by]
+[audit_trails.record.is_replaced_by]
 rust = [
   "RecordCorrection.is_replaced_by",
 ]
@@ -1168,23 +1168,23 @@ wasm = [
   "WasmRecordCorrection.is_replaced_by",
 ]
 
-[audit_trail.record.is_correction]
+[audit_trails.record.is_correction]
 rust = [
   "RecordCorrection::is_correction",
 ]
 wasm = []
 
-[audit_trail.record.is_replaced]
+[audit_trails.record.is_replaced]
 rust = [
   "RecordCorrection::is_replaced",
 ]
 wasm = []
 
 # =============================================================================
-# Module: audit_trail::record_tags (audit-trail-move/sources/record_tags.move)
+# Module: audit_trails::record_tags (audit-trail-move/sources/record_tags.move)
 # =============================================================================
 
-[audit_trail.record_tags.RoleTags]
+[audit_trails.record_tags.RoleTags]
 rust = [
   "RoleTags",
   "RoleTags::new",
@@ -1197,7 +1197,7 @@ wasm = [
   "WasmRoleTags::new",
 ]
 
-[audit_trail.record_tags.new_role_tags]
+[audit_trails.record_tags.new_role_tags]
 rust = [
   "RoleTags::new",
   "RoleTags::to_ptb",
@@ -1206,7 +1206,7 @@ wasm = [
   "WasmRoleTags::new",
 ]
 
-[audit_trail.record_tags.tags]
+[audit_trails.record_tags.tags]
 rust = [
   "RoleTags.tags",
 ]
@@ -1214,7 +1214,7 @@ wasm = [
   "WasmRoleTags.tags",
 ]
 
-[audit_trail.record_tags.TagRegistry]
+[audit_trails.record_tags.TagRegistry]
 rust = [
   "TagRegistry",
   "TagRegistry::len",
@@ -1231,7 +1231,7 @@ wasm = [
   "WasmOnChainAuditTrail::tags",
 ]
 
-[audit_trail.record_tags.tag_map]
+[audit_trails.record_tags.tag_map]
 rust = [
   "TagRegistry.tag_map",
 ]

--- a/audit-trail-move/scripts/publish_package.sh
+++ b/audit-trail-move/scripts/publish_package.sh
@@ -33,7 +33,7 @@ audit_trail_package_id=$(
 
 if [[ -z "$audit_trail_package_id" || "$audit_trail_package_id" == "null" ]]; then
     echo "$response" >&2
-    echo "failed to extract audit_trail package ID from publish response" >&2
+    echo "failed to extract IotaAuditTrails package ID from publish response" >&2
     exit 1
 fi
 

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -160,10 +160,9 @@ public fun new_trail_metadata(name: String, description: Option<String>): Immuta
 /// Creates a new audit trail with an optional initial record and shares it on-chain.
 ///
 /// Initialises the trail's role map with a single role named "Admin" associated with
-/// the permissions `DeleteAuditTrail`, `AddCapabilities`, `RevokeCapabilities`,
-/// `AddRoles`, `UpdateRoles` and `DeleteRoles`. The creator receives an initial admin
-/// capability that may be used to define further roles and to issue capabilities to
-/// other users.
+/// the permission set defined by the `permission::admin_permissions()` function. The
+/// creator receives an initial admin capability that may be used to define further
+/// roles and to issue capabilities to other users.
 ///
 /// When `initial_record` is provided it is stored at sequence number `0`; otherwise
 /// the trail is created empty. If the initial record carries a tag, that tag must

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -971,7 +971,7 @@ public fun remove_record_tag<D: store + copy>(
 /// * `ERecordTagNotDefined` when any tag listed in `role_tags` is not in the
 ///   trail's tag registry.
 ///
-/// Emits a `RoleCreated` event on success.
+/// Emits a `tf_components::role_map::RoleCreated` event on success.
 public fun create_role<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1018,14 +1018,15 @@ public fun create_role<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ERoleDoesNotExist` when `role` is not defined on the trail.
-/// * `EInitialAdminPermissionsInconsistent` when updating the initial-admin role
-///   with `new_permissions` that does not include every permission configured in
-///   the trail's role- and capability-admin permission sets.
+/// * `tf_components::role_map::ERoleDoesNotExist` when `role` is not defined on
+///   the trail.
+/// * `tf_components::role_map::EInitialAdminPermissionsInconsistent` when updating
+///   the initial-admin role with `new_permissions` that does not include every
+///   permission configured in the trail's role- and capability-admin permission sets.
 /// * `ERecordTagNotDefined` when any tag in the new `role_tags` is not in the
 ///   trail's tag registry.
 ///
-/// Emits a `RoleUpdated` event on success.
+/// Emits a `tf_components::role_map::RoleUpdated` event on success.
 public fun update_role_permissions<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1084,11 +1085,12 @@ public fun update_role_permissions<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ERoleDoesNotExist` when `role` is not defined on the trail.
-/// * `EInitialAdminRoleCannotBeDeleted` when targeting the reserved initial-admin
-///   role.
+/// * `tf_components::role_map::ERoleDoesNotExist` when `role` is not defined on
+///   the trail.
+/// * `tf_components::role_map::EInitialAdminRoleCannotBeDeleted` when targeting the
+///   reserved initial-admin role.
 ///
-/// Emits a `RoleDeleted` event on success.
+/// Emits a `tf_components::role_map::RoleDeleted` event on success.
 public fun delete_role<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1125,13 +1127,14 @@ public fun delete_role<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ERoleDoesNotExist` when `role` is not defined on the trail.
+/// * `tf_components::role_map::ERoleDoesNotExist` when `role` is not defined on
+///   the trail.
 /// * `tf_components::capability::EValidityPeriodInconsistent` when `valid_from`
 ///   and `valid_until` are not consistent.
 ///
-/// Emits a `CapabilityIssued` event on success.
+/// Emits a `tf_components::role_map::CapabilityIssued` event on success.
 ///
-/// Returns the same receipt that is emitted as the `CapabilityIssued` event.
+/// Returns the same receipt that is emitted as the `tf_components::role_map::CapabilityIssued` event.
 public fun new_capability<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1195,12 +1198,12 @@ public fun new_capability<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ECapabilityToRevokeHasAlreadyBeenRevoked` when `cap_to_revoke` is already on
-///   the denylist.
-/// * `EInitialAdminCapabilityMustBeExplicitlyDestroyed` when `cap_to_revoke`
-///   identifies an initial admin capability.
+/// * `tf_components::role_map::ECapabilityToRevokeHasAlreadyBeenRevoked` when
+///   `cap_to_revoke` is already on the denylist.
+/// * `tf_components::role_map::EInitialAdminCapabilityMustBeExplicitlyDestroyed`
+///   when `cap_to_revoke` identifies an initial admin capability.
 ///
-/// Emits a `CapabilityRevoked` event on success.
+/// Emits a `tf_components::role_map::CapabilityRevoked` event on success.
 public fun revoke_capability<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1232,12 +1235,12 @@ public fun revoke_capability<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ECapabilityTargetKeyMismatch` when `cap_to_destroy` was not issued for this
-///   trail.
-/// * `EInitialAdminCapabilityMustBeExplicitlyDestroyed` when `cap_to_destroy` is
-///   an initial admin capability.
+/// * `tf_components::role_map::ECapabilityTargetKeyMismatch` when `cap_to_destroy`
+///   was not issued for this trail.
+/// * `tf_components::role_map::EInitialAdminCapabilityMustBeExplicitlyDestroyed`
+///   when `cap_to_destroy` is an initial admin capability.
 ///
-/// Emits a `CapabilityDestroyed` event on success.
+/// Emits a `tf_components::role_map::CapabilityDestroyed` event on success.
 public fun destroy_capability<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,
@@ -1269,12 +1272,12 @@ public fun destroy_capability<D: store + copy>(
 ///
 /// Aborts with:
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
-/// * `ECapabilityTargetKeyMismatch` when `cap_to_destroy` was not issued for this
-///   trail.
-/// * `ECapabilityIsNotInitialAdmin` when `cap_to_destroy` is not an initial admin
-///   capability.
+/// * `tf_components::role_map::ECapabilityTargetKeyMismatch` when `cap_to_destroy`
+///   was not issued for this trail.
+/// * `tf_components::role_map::ECapabilityIsNotInitialAdmin` when `cap_to_destroy`
+///   is not an initial admin capability.
 ///
-/// Emits a `CapabilityDestroyed` event on success.
+/// Emits a `tf_components::role_map::CapabilityDestroyed` event on success.
 public fun destroy_initial_admin_capability<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap_to_destroy: Capability,
@@ -1298,12 +1301,12 @@ public fun destroy_initial_admin_capability<D: store + copy>(
 /// * `EPackageVersionMismatch` when the trail is at a different package version.
 /// * any error documented by `RoleMap::assert_capability_valid` when `cap` fails
 ///   authorization checks.
-/// * `ECapabilityIsNotInitialAdmin` when `cap_to_revoke` does not identify an
-///   initial admin capability.
-/// * `ECapabilityToRevokeHasAlreadyBeenRevoked` when it is already on the
-///   denylist.
+/// * `tf_components::role_map::ECapabilityIsNotInitialAdmin` when `cap_to_revoke`
+///   does not identify an initial admin capability.
+/// * `tf_components::role_map::ECapabilityToRevokeHasAlreadyBeenRevoked` when it is
+///   already on the denylist.
 ///
-/// Emits a `CapabilityRevoked` event on success.
+/// Emits a `tf_components::role_map::CapabilityRevoked` event on success.
 public fun revoke_initial_admin_capability<D: store + copy>(
     self: &mut AuditTrail<D>,
     cap: &Capability,

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Audit Trail with role-based access control and timelock
+/// Audit Trails with role-based access control and timelock
 /// A trail is a tamper-proof, sequential chain of notarized records where each
 /// entry references its predecessor, ensuring verifiable continuity and
 /// integrity.

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -5,9 +5,9 @@
 /// A trail is a tamper-proof, sequential chain of notarized records where each
 /// entry references its predecessor, ensuring verifiable continuity and
 /// integrity.
-module audit_trail::main;
+module audit_trails::main;
 
-use audit_trail::{
+use audit_trails::{
     locking::{
         Self,
         LockingConfig,

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -160,9 +160,10 @@ public fun new_trail_metadata(name: String, description: Option<String>): Immuta
 /// Creates a new audit trail with an optional initial record and shares it on-chain.
 ///
 /// Initialises the trail's role map with a single role named "Admin" associated with
-/// the permission set defined by the `permission::admin_permissions()` function. The
-/// creator receives an initial admin capability that may be used to define further
-/// roles and to issue capabilities to other users.
+/// the permissions `DeleteAuditTrail`, `AddCapabilities`, `RevokeCapabilities`,
+/// `AddRoles`, `UpdateRoles` and `DeleteRoles`. The creator receives an initial admin
+/// capability that may be used to define further roles and to issue capabilities to
+/// other users.
 ///
 /// When `initial_record` is provided it is stored at sequence number `0`; otherwise
 /// the trail is created empty. If the initial record carries a tag, that tag must

--- a/audit-trail-move/sources/locking.move
+++ b/audit-trail-move/sources/locking.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Locking configuration for audit trail records
-module audit_trail::locking;
+module audit_trails::locking;
 
 use iota::clock::Clock;
 use tf_components::timelock::{Self, TimeLock};

--- a/audit-trail-move/sources/locking.move
+++ b/audit-trail-move/sources/locking.move
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Locking configuration for Audit Trail records
+/// Locking configuration for audit trail records
 module audit_trail::locking;
 
 use iota::clock::Clock;

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -94,9 +94,19 @@ public fun has_permission(set: &VecSet<Permission>, perm: &Permission): bool {
     vec_set::contains(set, perm)
 }
 
-// ------Functions creating permission sets for often used roles ---------
+// ------ Functions creating permission sets for often used roles ---------
 
-/// Create permissions typically used for the `Admin` role
+/// Creates the permission set typically used for the `Admin` role.
+///
+/// Includes the following permissions:
+/// * `AddCapabilities`
+/// * `RevokeCapabilities`
+/// * `AddRecordTags`
+/// * `DeleteRecordTags`
+/// * `AddRoles`
+/// * `UpdateRoles`
+/// * `DeleteRoles`
+/// * `Migrate`
 public fun admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -110,7 +120,12 @@ public fun admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `RecordAdmin` role
+/// Creates the permission set typically used for the `RecordAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRecord`
+/// * `DeleteRecord`
+/// * `CorrectRecord`
 public fun record_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record());
@@ -119,7 +134,13 @@ public fun record_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `LockingAdmin` role
+/// Creates the permission set typically used for the `LockingAdmin` role.
+///
+/// Includes the following permissions:
+/// * `UpdateLockingConfig`
+/// * `UpdateLockingConfigForDeleteTrail`
+/// * `UpdateLockingConfigForDeleteRecord`
+/// * `UpdateLockingConfigForWrite`
 public fun locking_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_locking_config());
@@ -129,7 +150,12 @@ public fun locking_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `RoleAdmin` role
+/// Creates the permission set typically used for the `RoleAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRoles`
+/// * `UpdateRoles`
+/// * `DeleteRoles`
 public fun role_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_roles());
@@ -138,7 +164,11 @@ public fun role_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typically used for the `TagAdmin` role
+/// Creates the permission set typically used for the `TagAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRecordTags`
+/// * `DeleteRecordTags`
 public fun tag_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record_tags());
@@ -146,7 +176,11 @@ public fun tag_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `CapAdmin` role
+/// Creates the permission set typically used for the `CapAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddCapabilities`
+/// * `RevokeCapabilities`
 public fun cap_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -154,7 +188,11 @@ public fun cap_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `MetadataAdmin` role
+/// Creates the permission set typically used for the `MetadataAdmin` role.
+///
+/// Includes the following permissions:
+/// * `UpdateMetadata`
+/// * `DeleteMetadata`
 public fun metadata_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_metadata());

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Permission system for role-based access control
-module audit_trail::permission;
+module audit_trails::permission;
 
 use iota::vec_set::{Self, VecSet};
 

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -6,10 +6,10 @@ module audit_trail::permission;
 
 use iota::vec_set::{Self, VecSet};
 
-/// Existing permissions for the Audit Trail object
+/// Existing permissions for the `AuditTrail` object
 public enum Permission has copy, drop, store {
     // --- Whole Audit Trail related - Proposed role: `Admin` ---
-    /// Destroy the whole Audit Trail object
+    /// Destroy the whole `AuditTrail` object
     DeleteAuditTrail,
     /// Delete records in batches for cleanup workflows
     DeleteAllRecords,
@@ -25,9 +25,9 @@ public enum Permission has copy, drop, store {
     UpdateLockingConfig,
     /// Update the delete_record_lock configuration which is part of the locking configuration
     UpdateLockingConfigForDeleteRecord,
-    /// Update the delete_lock configuration for the whole Audit Trail
+    /// Update the delete_lock configuration for the whole `AuditTrail` object
     UpdateLockingConfigForDeleteTrail,
-    /// Update the write_lock configuration for the whole Audit Trail
+    /// Update the write_lock configuration for the whole `AuditTrail` object
     UpdateLockingConfigForWrite,
     // --- Role Management - Proposed role: `RoleAdmin` ---
     /// Add new roles with associated permissions
@@ -164,7 +164,7 @@ public fun metadata_admin_permissions(): VecSet<Permission> {
 
 // ------- Constructor functions for all Permission variants -------------
 
-/// Returns a permission allowing to destroy the whole Audit Trail object
+/// Returns a permission allowing to destroy the whole `AuditTrail` object
 public fun delete_audit_trail(): Permission {
     Permission::DeleteAuditTrail
 }
@@ -199,12 +199,12 @@ public fun update_locking_config_for_delete_record(): Permission {
     Permission::UpdateLockingConfigForDeleteRecord
 }
 
-/// Returns a permission allowing to update the delete_lock configuration for the whole Audit Trail
+/// Returns a permission allowing to update the delete_lock configuration for the whole `AuditTrail` object
 public fun update_locking_config_for_delete_trail(): Permission {
     Permission::UpdateLockingConfigForDeleteTrail
 }
 
-/// Returns a permission allowing to update the write_lock configuration for the whole Audit Trail
+/// Returns a permission allowing to update the write_lock configuration for the whole `AuditTrail` object
 public fun update_locking_config_for_write(): Permission {
     Permission::UpdateLockingConfigForWrite
 }

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -94,19 +94,9 @@ public fun has_permission(set: &VecSet<Permission>, perm: &Permission): bool {
     vec_set::contains(set, perm)
 }
 
-// ------ Functions creating permission sets for often used roles ---------
+// ------Functions creating permission sets for often used roles ---------
 
-/// Creates the permission set typically used for the `Admin` role.
-///
-/// Includes the following permissions:
-/// * `AddCapabilities`
-/// * `RevokeCapabilities`
-/// * `AddRecordTags`
-/// * `DeleteRecordTags`
-/// * `AddRoles`
-/// * `UpdateRoles`
-/// * `DeleteRoles`
-/// * `Migrate`
+/// Create permissions typically used for the `Admin` role
 public fun admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -120,12 +110,7 @@ public fun admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `RecordAdmin` role.
-///
-/// Includes the following permissions:
-/// * `AddRecord`
-/// * `DeleteRecord`
-/// * `CorrectRecord`
+/// Create permissions typical used for the `RecordAdmin` role
 public fun record_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record());
@@ -134,13 +119,7 @@ public fun record_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `LockingAdmin` role.
-///
-/// Includes the following permissions:
-/// * `UpdateLockingConfig`
-/// * `UpdateLockingConfigForDeleteTrail`
-/// * `UpdateLockingConfigForDeleteRecord`
-/// * `UpdateLockingConfigForWrite`
+/// Create permissions typical used for the `LockingAdmin` role
 public fun locking_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_locking_config());
@@ -150,12 +129,7 @@ public fun locking_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `RoleAdmin` role.
-///
-/// Includes the following permissions:
-/// * `AddRoles`
-/// * `UpdateRoles`
-/// * `DeleteRoles`
+/// Create permissions typical used for the `RoleAdmin` role
 public fun role_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_roles());
@@ -164,11 +138,7 @@ public fun role_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `TagAdmin` role.
-///
-/// Includes the following permissions:
-/// * `AddRecordTags`
-/// * `DeleteRecordTags`
+/// Create permissions typically used for the `TagAdmin` role
 public fun tag_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record_tags());
@@ -176,11 +146,7 @@ public fun tag_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `CapAdmin` role.
-///
-/// Includes the following permissions:
-/// * `AddCapabilities`
-/// * `RevokeCapabilities`
+/// Create permissions typical used for the `CapAdmin` role
 public fun cap_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -188,11 +154,7 @@ public fun cap_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Creates the permission set typically used for the `MetadataAdmin` role.
-///
-/// Includes the following permissions:
-/// * `UpdateMetadata`
-/// * `DeleteMetadata`
+/// Create permissions typical used for the `MetadataAdmin` role
 public fun metadata_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_metadata());

--- a/audit-trail-move/sources/record.move
+++ b/audit-trail-move/sources/record.move
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Record module for Audit Trail entries
+/// Record module for audit trail entries
 ///
 /// A Record represents a single entry in an audit trail, stored in a
 /// LinkedTable and addressed by trail_id + sequence_number.

--- a/audit-trail-move/sources/record.move
+++ b/audit-trail-move/sources/record.move
@@ -5,7 +5,7 @@
 ///
 /// A Record represents a single entry in an audit trail, stored in a
 /// LinkedTable and addressed by trail_id + sequence_number.
-module audit_trail::record;
+module audit_trails::record;
 
 use iota::vec_set::{Self, VecSet};
 use std::string::String;
@@ -79,7 +79,7 @@ public struct InitialRecord<D: store + copy> has copy, drop, store {
 
 // ===== Constructors =====
 
-/// Creates an `InitialRecord` to be passed to `audit_trail::create`.
+/// Creates an `InitialRecord` to be passed to `audit_trails::create`.
 ///
 /// Returns the constructed `InitialRecord`.
 public fun new_initial_record<D: store + copy>(

--- a/audit-trail-move/sources/record_tags.move
+++ b/audit-trail-move/sources/record_tags.move
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Record tag types and helper predicates for Audit Trails.
-module audit_trail::record_tags;
+module audit_trails::record_tags;
 
-use audit_trail::permission::Permission;
+use audit_trails::permission::Permission;
 use iota::{vec_map::{Self, VecMap}, vec_set::{Self, VecSet}};
 use std::string::String;
 use tf_components::{capability::Capability, role_map::{Self, RoleMap}};

--- a/audit-trail-move/sources/record_tags.move
+++ b/audit-trail-move/sources/record_tags.move
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Record tag types and helper predicates for Audit Trail.
+/// Record tag types and helper predicates for Audit Trails.
 module audit_trail::record_tags;
 
 use audit_trail::permission::Permission;

--- a/audit-trail-move/tests/capability_tests.move
+++ b/audit-trail-move/tests/capability_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::capability_tests;
+module audit_trails::capability_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     main::AuditTrail,
     permission,
@@ -512,7 +512,7 @@ fun test_capability_lifecycle() {
     ts::end(scenario);
 }
 
-#[test, expected_failure(abort_code = audit_trail::role_map::ECapabilityIssuedToMismatch)]
+#[test, expected_failure(abort_code = audit_trails::role_map::ECapabilityIssuedToMismatch)]
 fun test_capability_issued_to_only() {
     let admin_user = @0xAD;
     let authorized_user = @0xB0B;
@@ -594,7 +594,7 @@ fun test_capability_issued_to_only() {
 // ===== Error Case Tests =====
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityHasBeenRevoked)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityHasBeenRevoked)]
 fun test_revoked_capability_cannot_be_used() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -686,7 +686,7 @@ fun test_revoked_capability_cannot_be_used() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ERoleDoesNotExist)]
+#[expected_failure(abort_code = audit_trails::role_map::ERoleDoesNotExist)]
 fun test_new_capability_for_nonexistent_role() {
     let admin_user = @0xAD;
 
@@ -726,7 +726,7 @@ fun test_new_capability_for_nonexistent_role() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_revoke_capability_permission_denied() {
     let admin_user = @0xAD;
     let user1 = @0xB0B;
@@ -825,7 +825,7 @@ fun test_revoke_capability_permission_denied() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_new_capability_permission_denied() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -912,7 +912,7 @@ fun test_new_capability_permission_denied() {
 /// - Capability can be used after valid_from timestamp
 /// - Capability is not restricted by address or end time
 /// - Capability cannot be used before valid_from timestamp
-#[test, expected_failure(abort_code = audit_trail::role_map::ECapabilityTimeConstraintsNotMet)]
+#[test, expected_failure(abort_code = audit_trails::role_map::ECapabilityTimeConstraintsNotMet)]
 fun test_capability_valid_from_only() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -998,7 +998,7 @@ fun test_capability_valid_from_only() {
 /// - Capability can be used before valid_until timestamp
 /// - Capability is not restricted by address or start time
 /// - Capability cannot be used after valid_until timestamp
-#[test, expected_failure(abort_code = audit_trail::role_map::ECapabilityTimeConstraintsNotMet)]
+#[test, expected_failure(abort_code = audit_trails::role_map::ECapabilityTimeConstraintsNotMet)]
 fun test_capability_valid_until_only() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -1125,7 +1125,7 @@ fun test_capability_time_window() {
 ///
 /// This test validates:
 /// - Capability cannot be used before valid_from
-#[test, expected_failure(abort_code = audit_trail::role_map::ECapabilityTimeConstraintsNotMet)]
+#[test, expected_failure(abort_code = audit_trails::role_map::ECapabilityTimeConstraintsNotMet)]
 fun test_capability_time_window_before_valid_from() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -1170,7 +1170,7 @@ fun test_capability_time_window_before_valid_from() {
 ///
 /// This test validates:
 /// - Capability cannot be used after valid_until
-#[test, expected_failure(abort_code = audit_trail::role_map::ECapabilityTimeConstraintsNotMet)]
+#[test, expected_failure(abort_code = audit_trails::role_map::ECapabilityTimeConstraintsNotMet)]
 fun test_capability_time_window_after_valid_until() {
     let admin_user = @0xAD;
     let user = @0xB0B;

--- a/audit-trail-move/tests/create_audit_trail_tests.move
+++ b/audit-trail-move/tests/create_audit_trail_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::create_audit_trail_tests;
+module audit_trails::create_audit_trail_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     main::{Self, AuditTrail, initial_admin_role_name},
     permission,
@@ -236,7 +236,7 @@ fun test_create_with_tagged_initial_record_tracks_tag_usage() {
     ts::end(scenario);
 }
 
-#[test, expected_failure(abort_code = audit_trail::main::ERecordTagInUse)]
+#[test, expected_failure(abort_code = audit_trails::main::ERecordTagInUse)]
 fun test_create_with_tagged_initial_record_blocks_tag_removal() {
     let admin = @0xD;
     let mut scenario = ts::begin(admin);
@@ -453,7 +453,7 @@ fun test_create_metadata_admin_role() {
         let (admin_cap, mut trail, clock) = fetch_capability_trail_and_clock(&mut scenario);
         // Create the MetadataAdmin role using the admin capability
         let metadata_admin_role_name = string::utf8(b"MetadataAdmin");
-        let metadata_admin_perms = audit_trail::permission::metadata_admin_permissions();
+        let metadata_admin_perms = audit_trails::permission::metadata_admin_permissions();
 
         trail
             .access_mut()
@@ -471,16 +471,16 @@ fun test_create_metadata_admin_role() {
 
         // Verify the role has the correct permissions
         assert!(
-            audit_trail::permission::has_permission(
+            audit_trails::permission::has_permission(
                 role_perms,
-                &audit_trail::permission::update_metadata(),
+                &audit_trails::permission::update_metadata(),
             ),
             2,
         );
         assert!(
-            audit_trail::permission::has_permission(
+            audit_trails::permission::has_permission(
                 role_perms,
-                &audit_trail::permission::delete_metadata(),
+                &audit_trails::permission::delete_metadata(),
             ),
             3,
         );

--- a/audit-trail-move/tests/locking_tests.move
+++ b/audit-trail-move/tests/locking_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::locking_tests;
+module audit_trails::locking_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     main::{Self, AuditTrail},
     permission,
@@ -348,7 +348,7 @@ fun test_update_locking_config() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_update_locking_config_permission_denied() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -495,7 +495,7 @@ fun test_update_delete_record_window() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_update_delete_record_window_permission_denied() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -1117,7 +1117,7 @@ fun test_delete_records_batch_skips_locked_records() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ETrailNotEmpty)]
+#[expected_failure(abort_code = audit_trails::main::ETrailNotEmpty)]
 fun test_delete_audit_trail_fails_while_not_empty() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);

--- a/audit-trail-move/tests/metadata_tests.move
+++ b/audit-trail-move/tests/metadata_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::metadata_tests;
+module audit_trails::metadata_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     permission,
     test_utils::{
@@ -141,7 +141,7 @@ fun test_update_metadata_success() {
 // ===== Error Case Tests =====
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_update_metadata_permission_denied() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -213,7 +213,7 @@ fun test_update_metadata_permission_denied() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityHasBeenRevoked)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityHasBeenRevoked)]
 fun test_update_metadata_revoked_capability() {
     let admin_user = @0xAD;
     let metadata_admin_user = @0xB0B;

--- a/audit-trail-move/tests/permission_tests.move
+++ b/audit-trail-move/tests/permission_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::permission_tests;
+module audit_trails::permission_tests;
 
-use audit_trail::permission;
+use audit_trails::permission;
 use iota::vec_set;
 
 #[test]

--- a/audit-trail-move/tests/record_tests.move
+++ b/audit-trail-move/tests/record_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::record_tests;
+module audit_trails::record_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     main::{Self, AuditTrail},
     permission,
@@ -320,7 +320,7 @@ fun test_delete_records_batch_with_matching_role_tags() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagNotAllowed)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagNotAllowed)]
 fun test_add_tagged_record_requires_matching_role_tags() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -389,7 +389,7 @@ fun test_add_tagged_record_requires_matching_role_tags() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagNotAllowed)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagNotAllowed)]
 fun test_delete_tagged_record_requires_matching_role_tags() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -612,7 +612,7 @@ fun test_delete_records_batch_skips_records_without_matching_role_tags() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagNotDefined)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagNotDefined)]
 fun test_add_tagged_record_requires_trail_defined_tag() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -679,7 +679,7 @@ fun test_add_tagged_record_requires_trail_defined_tag() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagInUse)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagInUse)]
 fun test_remove_record_tag_rejects_in_use_tag() {
     let admin = @0xAD;
     let writer = @0xB0B;
@@ -845,7 +845,7 @@ fun test_add_multiple_records() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_add_record_permission_denied() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -993,7 +993,7 @@ fun test_delete_record_success() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_delete_record_permission_denied() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -1339,7 +1339,7 @@ fun test_delete_record_after_time_lock_expires() {
 // ===== Delete Records Batch Tests =====
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_delete_records_batch_requires_delete_all_records_permission() {
     let admin = @0xAD;
     let mut scenario = ts::begin(admin);
@@ -1432,7 +1432,7 @@ fun test_get_record() {
         let trail = ts::take_shared<AuditTrail<Data>>(&scenario);
 
         let record = trail.get_record(0);
-        let data = audit_trail::record::data(record);
+        let data = audit_trails::record::data(record);
 
         assert!(record::bytes(data) == option::some(b"Test data"), 0);
 

--- a/audit-trail-move/tests/role_tests.move
+++ b/audit-trail-move/tests/role_tests.move
@@ -1,8 +1,8 @@
 #[allow(lint(abort_without_constant))]
 #[test_only]
-module audit_trail::role_tests;
+module audit_trails::role_tests;
 
-use audit_trail::{
+use audit_trails::{
     locking,
     main::{initial_admin_role_name, AuditTrail},
     permission,
@@ -220,7 +220,7 @@ fun test_role_based_permission_delegation() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagNotDefined)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagNotDefined)]
 fun test_create_role_rejects_undefined_record_tags() {
     let admin_user = @0xAD;
     let mut scenario = ts::begin(admin_user);
@@ -325,7 +325,7 @@ fun test_delete_role_success() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagInUse)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagInUse)]
 fun test_remove_record_tag_rejects_role_only_usage() {
     let admin_user = @0xAD;
     let mut scenario = ts::begin(admin_user);
@@ -375,7 +375,7 @@ fun test_remove_record_tag_rejects_role_only_usage() {
 // ===== Error Case Tests =====
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_create_role_permission_denied() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -453,7 +453,7 @@ fun test_create_role_permission_denied() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_delete_role_permission_denied() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -535,7 +535,7 @@ fun test_delete_role_permission_denied() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ECapabilityPermissionDenied)]
+#[expected_failure(abort_code = audit_trails::role_map::ECapabilityPermissionDenied)]
 fun test_update_role_permissions_permission_denied() {
     let admin_user = @0xAD;
     let user = @0xB0B;
@@ -626,7 +626,7 @@ fun test_update_role_permissions_permission_denied() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ERoleDoesNotExist)]
+#[expected_failure(abort_code = audit_trails::role_map::ERoleDoesNotExist)]
 fun test_get_role_permissions_nonexistent() {
     let admin_user = @0xAD;
 
@@ -726,7 +726,7 @@ fun test_update_role_permissions_success() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::main::ERecordTagNotDefined)]
+#[expected_failure(abort_code = audit_trails::main::ERecordTagNotDefined)]
 fun test_update_role_permissions_rejects_undefined_record_tags() {
     let admin_user = @0xAD;
     let mut scenario = ts::begin(admin_user);
@@ -775,7 +775,7 @@ fun test_update_role_permissions_rejects_undefined_record_tags() {
 }
 
 #[test]
-#[expected_failure(abort_code = audit_trail::role_map::ERoleDoesNotExist)]
+#[expected_failure(abort_code = audit_trails::role_map::ERoleDoesNotExist)]
 fun test_update_role_permissions_nonexistent() {
     let admin_user = @0xAD;
 

--- a/audit-trail-move/tests/test_utils.move
+++ b/audit-trail-move/tests/test_utils.move
@@ -1,7 +1,7 @@
 #[test_only]
-module audit_trail::test_utils;
+module audit_trails::test_utils;
 
-use audit_trail::{locking, main::{Self, AuditTrail}, record::{Self, Data}};
+use audit_trails::{locking, main::{Self, AuditTrail}, record::{Self, Data}};
 use iota::{clock::{Self, Clock}, test_scenario::{Self as ts, Scenario}};
 use std::string;
 use tf_components::{capability::Capability, role_map::RoleMap};

--- a/audit-trail-rs/Cargo.toml
+++ b/audit-trail-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "audit_trail"
+name = "audit_trails"
 version = "0.1.0-alpha"
 authors.workspace = true
 edition.workspace = true

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -1,14 +1,14 @@
-# IOTA Audit Trail Rust Package
+# IOTA Audit Trails Rust Package
 
 ## Introduction
 
-The Audit Trail Rust package provides the Rust client for structured record histories in the IOTA Notarization Toolkit.
+The Audit Trails Rust package provides the Rust client for structured record histories in the IOTA Notarization Toolkit.
 
 The package also provides an `AuditTrailBuilder` that creates audit trail objects on the IOTA ledger and an `AuditTrailHandle`
 that interacts with existing trails. The handle maps to one on-chain audit trail and provides typed APIs for records,
 access control, locking, tags, metadata, migration, and deletion.
 
-Use Audit Trail when you need a governed record history with sequential entries, role-based permissions, capabilities,
+Use Audit Trails when you need a governed record history with sequential entries, role-based permissions, capabilities,
 locking, and tagging. Use Single Notarization when you need one locked or dynamic notarized object for arbitrary data,
 documents, hashes, or latest-state records.
 
@@ -19,11 +19,11 @@ You can find the full IOTA Notarization Toolkit documentation [here](https://doc
 The following workflows demonstrate how `AuditTrailBuilder` and `AuditTrailHandle` instances create, update, govern, and
 delete audit trail objects on the ledger.
 
-### Creating an Audit Trail
+### Creating an `AuditTrail` Object
 
-An _Audit Trail_ is created on the ledger using the `AuditTrailClient::create_trail()` function. To create an _Audit
-Trail_, specify the following initial arguments with the `AuditTrailBuilder` setter functions. The terms used here are
-defined in the [glossary below](#glossary).
+An `AuditTrail` on-chain object is created on the ledger using the `AuditTrailClient::create_trail()` function. To
+create an `AuditTrail` object, specify the following initial arguments with the `AuditTrailBuilder` setter functions.
+The terms used here are defined in the [glossary below](#glossary).
 
 - Optional `Initial Record` that becomes sequence number `0`
 - Optional `Immutable Metadata`
@@ -32,14 +32,14 @@ defined in the [glossary below](#glossary).
 - Optional `Record Tag Registry`
 - Optional initial admin address
 
-After an _Audit Trail_ has been created, the creator receives an Admin capability object. This capability authorizes
+After an `AuditTrail` object has been created, the creator receives an Admin capability object. This capability authorizes
 administrative operations such as defining roles, issuing capabilities, updating locks, managing tags, and deleting the
 trail.
 
-#### Creating a new Audit Trail on the Ledger
+#### Creating a new `AuditTrail` Object on the Ledger
 
 The following sequence diagram explains the interaction between the involved technical components and the `Admin` when an
-_Audit Trail_ is created on the ledger:
+`AuditTrail` object is created on the ledger:
 
 ```mermaid
 sequenceDiagram
@@ -77,7 +77,7 @@ or `TrailRecords::list_page()`.
 To add a record, the sender must hold a capability whose role allows record writes. Tagged records must use a tag already
 defined in the trail's tag registry, and the sender's role must allow that tag.
 
-#### Appending a Record to an Existing Audit Trail
+#### Appending a Record to an Existing `AuditTrail` Object
 
 The following sequence diagram shows the component interaction when a `Record Admin` appends a new record:
 
@@ -102,7 +102,7 @@ sequenceDiagram
     Lib ->>- RecordAdmin: RecordAdded + IotaTransactionBlockResponse
 ```
 
-#### Reading Records from an Existing Audit Trail
+#### Reading Records from an Existing `AuditTrail` Object
 
 The following sequence diagram explains the component interaction for `Verifiers` or other parties fetching trail
 records:
@@ -202,12 +202,15 @@ sequenceDiagram
     Lib ->>- LockingAdmin: () + IotaTransactionBlockResponse
 ```
 
-#### Deleting an Audit Trail
+#### Deleting an `AuditTrail` Object
 
-The lifecycle of an _Audit Trail_ deletion can be described as:
+The workflow of deletion an `AuditTrail` object can be described as:
 
 - Delete all eligible unlocked records with `TrailRecords::delete()` or `TrailRecords::delete_records_batch()`
-- Wait until the `Delete Trail Lock` allows trail deletion, if a lock is configured
+- If not all records have been deleted:
+  - if a lock is configured, wait until the `Delete Trail Lock` allows trail deletion,
+  - if records are tag protected, notify a user with an appropriate role granting the needed tag access,
+    to delete the remaining records 
 - Delete the trail object with `AuditTrailHandle::delete_audit_trail()`
 
 The trail deletion process does not remove records automatically. The trail must be empty before
@@ -215,7 +218,7 @@ The trail deletion process does not remove records automatically. The trail must
 
 ## Glossary
 
-- `Audit Trail`: A shared on-chain object that stores ordered records, metadata, locking configuration, tag registry,
+- `AuditTrail` object: A shared on-chain object that stores ordered records, metadata, locking configuration, tag registry,
   roles, and capability state.
 - `Record`: A single trail entry stored at a sequence number. Records contain `Data`, optional record metadata, an
   optional tag, and creation information.
@@ -245,9 +248,9 @@ The trail deletion process does not remove records automatically. The trail must
 
 ## Documentation And Resources
 
-- [Audit Trail Move Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-move): On-chain contract package that defines the shared object model, permissions, locking, and events.
-- [Audit Trail Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm): JavaScript and TypeScript bindings for browser and Node.js integrations.
-- [Audit Trail Wasm Examples](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/examples/README.md): Runnable audit-trail examples for JS and TS consumers.
+- [Audit Trails Move Package](https://github.com/iotaledger/notarization/tree/main/audit-trail-move): On-chain contract package that defines the shared object model, permissions, locking, and events.
+- [Audit Trails Wasm Package](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm): JavaScript and TypeScript bindings for browser and Node.js integrations.
+- [Audit Trails Wasm Examples](https://github.com/iotaledger/notarization/tree/main/bindings/wasm/audit_trail_wasm/examples/README.md): Runnable audit-trail examples for JS and TS consumers.
 - [Repository Examples](https://github.com/iotaledger/notarization/tree/main/examples/README.md): End-to-end examples across the Notarization Toolkit.
 
 This README is also used as the crate-level rustdoc entry point, while the source files provide detailed API documentation for all public types and methods.

--- a/audit-trail-rs/README.md
+++ b/audit-trail-rs/README.md
@@ -210,7 +210,7 @@ The workflow of deletion an `AuditTrail` object can be described as:
 - If not all records have been deleted:
   - if a lock is configured, wait until the `Delete Trail Lock` allows trail deletion,
   - if records are tag protected, notify a user with an appropriate role granting the needed tag access,
-    to delete the remaining records 
+    to delete the remaining records
 - Delete the trail object with `AuditTrailHandle::delete_audit_trail()`
 
 The trail deletion process does not remove records automatically. The trail must be empty before

--- a/audit-trail-rs/src/client/full_client.rs
+++ b/audit-trail-rs/src/client/full_client.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! # Audit Trail Client
+//! # Audit Trails Client
 //!
 //! The full client extends [`AuditTrailClientReadOnly`] with signing support and write
 //! transaction builders.

--- a/audit-trail-rs/src/client/full_client.rs
+++ b/audit-trail-rs/src/client/full_client.rs
@@ -12,8 +12,8 @@
 //! that you can configure before signing and submitting:
 //!
 //! ```rust,no_run
-//! # use audit_trail::AuditTrailClient;
-//! # use audit_trail::core::types::Data;
+//! # use audit_trails::AuditTrailClient;
+//! # use audit_trails::core::types::Data;
 //! # async fn example(
 //! #     client: &AuditTrailClient<
 //! #         impl secret_storage::Signer<iota_interaction::IotaKeySignature> + iota_interaction::OptionalSync,
@@ -42,8 +42,8 @@
 //! ## Example Workflow
 //!
 //! ```rust,no_run
-//! # use audit_trail::AuditTrailClient;
-//! # use audit_trail::core::types::{Data, PermissionSet, RoleTags};
+//! # use audit_trails::AuditTrailClient;
+//! # use audit_trails::core::types::{Data, PermissionSet, RoleTags};
 //! # async fn example(
 //! #     client: &AuditTrailClient<
 //! #         impl secret_storage::Signer<iota_interaction::IotaKeySignature> + iota_interaction::OptionalSync,
@@ -166,7 +166,7 @@ impl AuditTrailClient<NoSigner> {
     ///
     /// # Examples
     /// ```rust,ignore
-    /// # use audit_trail::client::AuditTrailClient;
+    /// # use audit_trails::client::AuditTrailClient;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> anyhow::Result<()> {

--- a/audit-trail-rs/src/core/access/mod.rs
+++ b/audit-trail-rs/src/core/access/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Role and capability management APIs for Audit Trail.
+//! Role and capability management APIs for Audit Trails.
 //!
 //! This module is the Rust-facing wrapper around the access-control state integrated into each audit trail.
 //! Roles grant [`crate::core::types::PermissionSet`] values, while capability objects bind one role to one trail and

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -118,9 +118,10 @@ impl AuditTrailBuilder {
     /// Finalizes the builder and creates the trail-creation transaction builder.
     ///
     /// Validates the configured [`LockingConfig`] before returning the transaction. Currently this rejects:
-    /// - [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
-    /// - [`TimeLock::UntilDestroyed`] used as `delete_trail_lock` (mirrors the Move
-    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    /// - [`LockingWindow::CountBased`](super::types::LockingWindow::CountBased) with `count == 0` (mirrors the
+    ///   Move `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`](super::types::TimeLock::UntilDestroyed) used as `delete_trail_lock` (mirrors
+    ///   the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -118,10 +118,9 @@ impl AuditTrailBuilder {
     /// Finalizes the builder and creates the trail-creation transaction builder.
     ///
     /// Validates the configured [`LockingConfig`] before returning the transaction. Currently this rejects:
-    /// - [`LockingWindow::CountBased`](super::types::LockingWindow::CountBased) with `count == 0` (mirrors the
-    ///   Move `ECountWindowMustBePositive` abort).
-    /// - [`TimeLock::UntilDestroyed`](super::types::TimeLock::UntilDestroyed) used as `delete_trail_lock` (mirrors
-    ///   the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    /// - [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`] used as `delete_trail_lock` (mirrors the Move
+    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Locking configuration APIs for Audit Trail.
+//! Locking configuration APIs for Audit Trails.
 
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};

--- a/audit-trail-rs/src/core/mod.rs
+++ b/audit-trail-rs/src/core/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Core handles, builders, transactions, and domain types for Audit Trail.
+//! Core handles, builders, transactions, and domain types for Audit Trails.
 //!
 //! This namespace contains the main trail-facing Rust API:
 //!

--- a/audit-trail-rs/src/core/records/mod.rs
+++ b/audit-trail-rs/src/core/records/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Record read and mutation APIs for Audit Trail.
+//! Record read and mutation APIs for Audit Trails.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/audit-trail-rs/src/core/tags/mod.rs
+++ b/audit-trail-rs/src/core/tags/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Record-tag registry APIs for Audit Trail.
+//! Record-tag registry APIs for Audit Trails.
 
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};

--- a/audit-trail-rs/src/core/types/RoleMap-README.md
+++ b/audit-trail-rs/src/core/types/RoleMap-README.md
@@ -122,7 +122,7 @@ Please note: Revoked capability objects still exist on-chain but will be rejecte
 ### Creating a trail and obtaining the Admin capability
 
 ```rust
-use audit_trail::core::types::{Data, InitialRecord, ImmutableMetadata};
+use audit_trails::core::types::{Data, InitialRecord, ImmutableMetadata};
 
 let created = client
     .create_trail()
@@ -139,7 +139,7 @@ let created = client
 ### Defining a new role
 
 ```rust
-use audit_trail::core::types::PermissionSet;
+use audit_trails::core::types::PermissionSet;
 
 client
     .trail(created.trail_id)
@@ -153,7 +153,7 @@ client
 ### Issuing a capability
 
 ```rust
-use audit_trail::core::types::CapabilityIssueOptions;
+use audit_trails::core::types::CapabilityIssueOptions;
 
 // Unrestricted — any holder may use this capability
 let cap = client
@@ -206,7 +206,7 @@ client
 ### Updating a role's permissions
 
 ```rust
-use audit_trail::core::types::{Permission, PermissionSet};
+use audit_trails::core::types::{Permission, PermissionSet};
 use std::collections::HashSet;
 
 client
@@ -286,7 +286,7 @@ let created = client
     .output;
 
 // 2. Create a role that may only write "finance" tagged records
-use audit_trail::core::types::RoleTags;
+use audit_trails::core::types::RoleTags;
 
 client
     .trail(created.trail_id)

--- a/audit-trail-rs/src/core/types/RoleMap-README.md
+++ b/audit-trail-rs/src/core/types/RoleMap-README.md
@@ -1,4 +1,4 @@
-# Role-Based Access Control for Audit Trail
+# Role-Based Access Control for Audit Trails
 
 Audit trails provide an access control registry (a.k.a. `RoleMap`), defining who may perform which
 operations by combining two primitives:

--- a/audit-trail-rs/src/core/types/event.rs
+++ b/audit-trail-rs/src/core/types/event.rs
@@ -10,7 +10,7 @@ use serde_aux::field_attributes::{deserialize_number_from_string, deserialize_op
 
 use super::{Permission, PermissionSet, RoleTags};
 
-/// Generic wrapper for Audit Trail events.
+/// Generic wrapper for Audit Trails events.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Event<D> {
     /// Parsed event payload.

--- a/audit-trail-rs/src/core/types/mod.rs
+++ b/audit-trail-rs/src/core/types/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared serializable domain types for Audit Trail.
+//! Shared serializable domain types for Audit Trails.
 //!
 //! These types stay close to the on-chain data model so they can deserialize ledger state and events while also
 //! serving as the typed inputs and outputs of the Rust client API.

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -141,6 +141,7 @@ impl PermissionSet {
                 Permission::AddRoles,
                 Permission::UpdateRoles,
                 Permission::DeleteRoles,
+                Permission::Migrate,
             ]),
         }
     }

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -128,16 +128,6 @@ impl PermissionSet {
     }
     /// Returns the recommended permission set for the `Admin` role.
     ///
-    /// Includes the following permissions:
-    /// - [`Permission::AddCapabilities`]
-    /// - [`Permission::RevokeCapabilities`]
-    /// - [`Permission::AddRecordTags`]
-    /// - [`Permission::DeleteRecordTags`]
-    /// - [`Permission::AddRoles`]
-    /// - [`Permission::UpdateRoles`]
-    /// - [`Permission::DeleteRoles`]
-    /// - [`Permission::Migrate`]
-    ///
     /// Mirrors `audit_trail::permission::admin_permissions` in the Move
     /// package. This is the same set the package seeds when a trail is
     /// created and the initial-admin capability is minted.
@@ -157,11 +147,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::AddRecord`]
-    /// - [`Permission::DeleteRecord`]
-    /// - [`Permission::CorrectRecord`]
     pub fn record_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -173,12 +158,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer locking rules.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::UpdateLockingConfig`]
-    /// - [`Permission::UpdateLockingConfigForDeleteTrail`]
-    /// - [`Permission::UpdateLockingConfigForDeleteRecord`]
-    /// - [`Permission::UpdateLockingConfigForWrite`]
     pub fn locking_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -191,11 +170,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::AddRoles`]
-    /// - [`Permission::UpdateRoles`]
-    /// - [`Permission::DeleteRoles`]
     pub fn role_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRoles, Permission::UpdateRoles, Permission::DeleteRoles]),
@@ -203,10 +177,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::AddRecordTags`]
-    /// - [`Permission::DeleteRecordTags`]
     pub fn tag_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRecordTags, Permission::DeleteRecordTags]),
@@ -214,10 +184,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to issue and revoke capabilities.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::AddCapabilities`]
-    /// - [`Permission::RevokeCapabilities`]
     pub fn cap_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::AddCapabilities, Permission::RevokeCapabilities]),
@@ -225,10 +191,6 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
-    ///
-    /// Includes the following permissions:
-    /// - [`Permission::UpdateMetadata`]
-    /// - [`Permission::DeleteMetadata`]
     pub fn metadata_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::UpdateMetadata, Permission::DeleteMetadata]),

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -128,6 +128,16 @@ impl PermissionSet {
     }
     /// Returns the recommended permission set for the `Admin` role.
     ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddCapabilities`]
+    /// - [`Permission::RevokeCapabilities`]
+    /// - [`Permission::AddRecordTags`]
+    /// - [`Permission::DeleteRecordTags`]
+    /// - [`Permission::AddRoles`]
+    /// - [`Permission::UpdateRoles`]
+    /// - [`Permission::DeleteRoles`]
+    /// - [`Permission::Migrate`]
+    ///
     /// Mirrors `audit_trail::permission::admin_permissions` in the Move
     /// package. This is the same set the package seeds when a trail is
     /// created and the initial-admin capability is minted.
@@ -147,6 +157,11 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRecord`]
+    /// - [`Permission::DeleteRecord`]
+    /// - [`Permission::CorrectRecord`]
     pub fn record_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -158,6 +173,12 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer locking rules.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::UpdateLockingConfig`]
+    /// - [`Permission::UpdateLockingConfigForDeleteTrail`]
+    /// - [`Permission::UpdateLockingConfigForDeleteRecord`]
+    /// - [`Permission::UpdateLockingConfigForWrite`]
     pub fn locking_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -170,6 +191,11 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRoles`]
+    /// - [`Permission::UpdateRoles`]
+    /// - [`Permission::DeleteRoles`]
     pub fn role_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRoles, Permission::UpdateRoles, Permission::DeleteRoles]),
@@ -177,6 +203,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRecordTags`]
+    /// - [`Permission::DeleteRecordTags`]
     pub fn tag_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRecordTags, Permission::DeleteRecordTags]),
@@ -184,6 +214,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to issue and revoke capabilities.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddCapabilities`]
+    /// - [`Permission::RevokeCapabilities`]
     pub fn cap_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::AddCapabilities, Permission::RevokeCapabilities]),
@@ -191,6 +225,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::UpdateMetadata`]
+    /// - [`Permission::DeleteMetadata`]
     pub fn metadata_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::UpdateMetadata, Permission::DeleteMetadata]),

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -128,7 +128,7 @@ impl PermissionSet {
     }
     /// Returns the recommended permission set for the `Admin` role.
     ///
-    /// Mirrors `audit_trail::permission::admin_permissions` in the Move
+    /// Mirrors `audit_trails::permission::admin_permissions` in the Move
     /// package. This is the same set the package seeds when a trail is
     /// created and the initial-admin capability is minted.
     pub fn admin_permissions() -> Self {

--- a/audit-trail-rs/src/core/types/record.rs
+++ b/audit-trail-rs/src/core/types/record.rs
@@ -63,7 +63,7 @@ impl InitialRecord {
     /// # Examples
     ///
     /// ```rust
-    /// use audit_trail::core::types::{Data, InitialRecord};
+    /// use audit_trails::core::types::{Data, InitialRecord};
     ///
     /// let record = InitialRecord::new(
     ///     Data::text("hello"),
@@ -135,7 +135,7 @@ impl RecordCorrection {
     /// ```rust
     /// use std::collections::HashSet;
     ///
-    /// use audit_trail::core::types::RecordCorrection;
+    /// use audit_trails::core::types::RecordCorrection;
     ///
     /// let correction = RecordCorrection::with_replaces(HashSet::from([1, 2]));
     ///
@@ -211,7 +211,7 @@ impl Data {
     /// # Examples
     ///
     /// ```rust
-    /// use audit_trail::core::types::Data;
+    /// use audit_trails::core::types::Data;
     ///
     /// assert_eq!(Data::bytes([1_u8, 2, 3]), Data::Bytes(vec![1, 2, 3]));
     /// ```
@@ -224,7 +224,7 @@ impl Data {
     /// # Examples
     ///
     /// ```rust
-    /// use audit_trail::core::types::Data;
+    /// use audit_trails::core::types::Data;
     ///
     /// assert_eq!(Data::text("hello"), Data::Text("hello".to_string()));
     /// ```

--- a/audit-trail-rs/src/error.rs
+++ b/audit-trail-rs/src/error.rs
@@ -5,7 +5,7 @@
 
 use crate::iota_interaction_adapter::AdapterError;
 
-/// Errors that can occur when reading or mutating an Audit Trail.
+/// Errors that can occur when reading or mutating an `AuditTrail` object.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[non_exhaustive]
 pub enum Error {

--- a/audit-trail-rs/src/package.rs
+++ b/audit-trail-rs/src/package.rs
@@ -1,10 +1,10 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Package management for Audit Trail smart contracts.
+//! Package management for Audit Trails smart contracts.
 //!
 //! This module handles package ID resolution and registry management
-//! for the Audit Trail Move Package.
+//! for the Audit Trails Move Package.
 
 #![allow(dead_code)]
 
@@ -22,7 +22,7 @@ use crate::error::Error;
 type PackageRegistryLock = RwLockReadGuard<'static, PackageRegistry>;
 type PackageRegistryLockMut = RwLockWriteGuard<'static, PackageRegistry>;
 
-/// Global registry for Audit Trail Package information.
+/// Global registry for Audit Trails Package information.
 static AUDIT_TRAIL_PACKAGE_REGISTRY: LazyLock<RwLock<PackageRegistry>> = LazyLock::new(|| {
     let package_history_json = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/audit-trail-rs/src/package.rs
+++ b/audit-trail-rs/src/package.rs
@@ -81,7 +81,7 @@ pub(crate) async fn resolve_package_ids(
         .or_else(|| package_registry.package_id(network))
         .ok_or_else(|| {
             Error::InvalidConfig(format!(
-                "no information for a published `audit_trail` package on network {network}; try to use `AuditTrailClientReadOnly::new_with_package_overrides`"
+                "no information for a published `IotaAuditTrails` package on network {network}; try to use `AuditTrailClientReadOnly::new_with_package_overrides`"
             ))
         })?;
     let resolved_network = match chain_id.as_str() {

--- a/audit-trail-rs/tests/e2e/access.rs
+++ b/audit-trail-rs/tests/e2e/access.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use audit_trail::core::types::{CapabilityIssueOptions, Data, Permission, PermissionSet, RoleTags};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, Permission, PermissionSet, RoleTags};
 use iota_interaction::types::base_types::IotaAddress;
 use product_common::core_client::CoreClient;
 

--- a/audit-trail-rs/tests/e2e/client.rs
+++ b/audit-trail-rs/tests/e2e/client.rs
@@ -48,7 +48,7 @@ async fn load_cached_package_ids(chain_id: &str) -> anyhow::Result<PublishedPack
     let mut parts = cache.trim().split(';');
     let audit_trail_package_id = parts
         .next()
-        .ok_or_else(|| anyhow!("missing audit_trail package ID in cache"))?;
+        .ok_or_else(|| anyhow!("missing IotaAuditTrails package ID in cache"))?;
     let tf_components_package_id = parts.next().unwrap_or_default();
     let cached_chain_id = parts.next().ok_or_else(|| anyhow!("missing chain ID in cache"))?;
 
@@ -58,7 +58,7 @@ async fn load_cached_package_ids(chain_id: &str) -> anyhow::Result<PublishedPack
 
     Ok(PublishedPackageIds {
         audit_trail_package_id: ObjectID::from_str(audit_trail_package_id)
-            .context("failed to parse cached audit_trail package ID")?,
+            .context("failed to parse cached IotaAuditTrails package ID")?,
         tf_components_package_id: if tf_components_package_id.is_empty() {
             None
         } else {
@@ -108,7 +108,7 @@ async fn publish_package_ids(iota_client: &IotaClient) -> anyhow::Result<Publish
         match key {
             "IOTA_AUDIT_TRAIL_PKG_ID" => {
                 let package_id =
-                    ObjectID::from_str(value).context("failed to parse published audit_trail package ID")?;
+                    ObjectID::from_str(value).context("failed to parse published IotaAuditTrails package ID")?;
                 audit_trail_package_id = Some(package_id);
             }
             "IOTA_TF_COMPONENTS_PKG_ID" => {

--- a/audit-trail-rs/tests/e2e/client.rs
+++ b/audit-trail-rs/tests/e2e/client.rs
@@ -7,11 +7,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     Capability, CapabilityIssueOptions, CapabilityIssued, Data, InitialRecord, Permission, PermissionSet, RoleCreated,
     RoleTags,
 };
-use audit_trail::{AuditTrailClient, PackageOverrides};
+use audit_trails::{AuditTrailClient, PackageOverrides};
 use iota_interaction::types::base_types::{IotaAddress, ObjectID, ObjectRef};
 use iota_interaction::types::crypto::PublicKey;
 use iota_interaction::{IOTA_LOCAL_NETWORK_URL, IotaClient, IotaClientBuilder};

--- a/audit-trail-rs/tests/e2e/locking.rs
+++ b/audit-trail-rs/tests/e2e/locking.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, InitialRecord, LockingConfig, LockingWindow, Permission, TimeLock,
 };
 use iota_interaction::types::base_types::ObjectID;

--- a/audit-trail-rs/tests/e2e/records.rs
+++ b/audit-trail-rs/tests/e2e/records.rs
@@ -3,10 +3,10 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, InitialRecord, LockingConfig, LockingWindow, Permission, RoleTags, TimeLock,
 };
-use audit_trail::error::Error;
+use audit_trails::error::Error;
 use iota_interaction::types::base_types::ObjectID;
 use product_common::core_client::CoreClient;
 use tokio::time::{Duration, sleep};

--- a/audit-trail-rs/tests/e2e/trail.rs
+++ b/audit-trail-rs/tests/e2e/trail.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, Permission, RoleTags,
     TimeLock,
 };

--- a/bindings/wasm/audit_trail_wasm/Cargo.toml
+++ b/bindings/wasm/audit_trail_wasm/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 readme = "README.md"
 repository = "https://github.com/iotaledger/notarization.git"
 resolver = "2"
-description = "Web Assembly bindings for the audit_trail crate."
+description = "Web Assembly bindings for the audit_trails crate."
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0.95"
-audit_trail = { path = "../../../audit-trail-rs", default-features = false, features = ["gas-station", "default-http-client"] }
+audit_trails = { path = "../../../audit-trail-rs", default-features = false, features = ["gas-station", "default-http-client"] }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.19", package = "iota_interaction", default-features = false }

--- a/bindings/wasm/audit_trail_wasm/README.md
+++ b/bindings/wasm/audit_trail_wasm/README.md
@@ -53,7 +53,7 @@ The package intentionally separates transaction construction from submission so 
 ## Minimal TypeScript shape
 
 ```ts
-import { AuditTrailClientReadOnly } from "@iota/audit-trail-wasm";
+import { AuditTrailClientReadOnly } from "@iota/audit-trails-wasm";
 
 const client = await AuditTrailClientReadOnly.create(iotaClient);
 const trail = client.trail(trailId);

--- a/bindings/wasm/audit_trail_wasm/README.md
+++ b/bindings/wasm/audit_trail_wasm/README.md
@@ -1,6 +1,6 @@
 # `audit_trail_wasm`
 
-`audit_trail_wasm` exposes the `audit_trail` Rust crate to JavaScript and TypeScript consumers through `wasm-bindgen`.
+`audit_trail_wasm` exposes the `audit_trails` Rust crate to JavaScript and TypeScript consumers through `wasm-bindgen`.
 
 It is designed for browser and other `wasm32` environments that need:
 

--- a/bindings/wasm/audit_trail_wasm/README.md
+++ b/bindings/wasm/audit_trail_wasm/README.md
@@ -53,7 +53,7 @@ The package intentionally separates transaction construction from submission so 
 ## Minimal TypeScript shape
 
 ```ts
-import { AuditTrailClientReadOnly } from "@iota/audit-trails-wasm";
+import { AuditTrailClientReadOnly } from "@iota/audit-trails";
 
 const client = await AuditTrailClientReadOnly.create(iotaClient);
 const trail = client.trail(trailId);

--- a/bindings/wasm/audit_trail_wasm/cypress/app/package-lock.json
+++ b/bindings/wasm/audit_trail_wasm/cypress/app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "vite-project",
             "version": "0.0.0",
             "dependencies": {
-                "@iota/audit-trail": "file:../..",
+                "@iota/audit-trails": "file:../..",
                 "@iota/iota-sdk": "^1.0.0"
             },
             "devDependencies": {
@@ -18,7 +18,7 @@
             }
         },
         "../..": {
-            "name": "@iota/audit-trail",
+            "name": "@iota/audit-trails",
             "version": "0.1.0-alpha",
             "license": "Apache-2.0",
             "dependencies": {
@@ -565,7 +565,7 @@
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
             }
         },
-        "node_modules/@iota/audit-trail": {
+        "node_modules/@iota/audit-trails": {
             "resolved": "../..",
             "link": true
         },

--- a/bindings/wasm/audit_trail_wasm/cypress/app/package.json
+++ b/bindings/wasm/audit_trail_wasm/cypress/app/package.json
@@ -15,6 +15,6 @@
     },
     "dependencies": {
         "@iota/iota-sdk": "^1.0.0",
-        "@iota/audit-trail": "file:../.."
+        "@iota/audit-trails": "file:../.."
     }
 }

--- a/bindings/wasm/audit_trail_wasm/cypress/app/src/audit_trail.ts
+++ b/bindings/wasm/audit_trail_wasm/cypress/app/src/audit_trail.ts
@@ -1,6 +1,6 @@
-import url from "@iota/audit-trail/web/audit_trail_wasm_bg.wasm?url";
+import url from "@iota/audit-trails/web/audit_trail_wasm_bg.wasm?url";
 
-import { init } from "@iota/audit-trail/web";
+import { init } from "@iota/audit-trails/web";
 import { main } from "../../../examples/dist/web/web-main";
 
 export const runTest = async (example: string) => {

--- a/bindings/wasm/audit_trail_wasm/docs/wasm/api_ref.md
+++ b/bindings/wasm/audit_trail_wasm/docs/wasm/api_ref.md
@@ -1,9 +1,0 @@
-**@iota/audit-trail API documentation**
-
----
-
-# @iota/audit-trail API documentation
-
-## Modules
-
-- [audit\_trail\_wasm](audit_trail_wasm/api_ref.md)

--- a/bindings/wasm/audit_trail_wasm/docs/wasm/audit_trails_wasm/api_ref.md
+++ b/bindings/wasm/audit_trail_wasm/docs/wasm/audit_trails_wasm/api_ref.md
@@ -1,9 +1,0 @@
-[**@iota/audit-trail API documentation**](../api_ref.md)
-
----
-
-# audit\_trail\_wasm
-
-## Classes
-
-- [DefaultHttpClient](classes/DefaultHttpClient.md)

--- a/bindings/wasm/audit_trail_wasm/docs/wasm/audit_trails_wasm/classes/DefaultHttpClient.md
+++ b/bindings/wasm/audit_trail_wasm/docs/wasm/audit_trails_wasm/classes/DefaultHttpClient.md
@@ -1,7 +1,0 @@
-[**@iota/audit-trail API documentation**](../../api_ref.md)
-
----
-
-# Class: DefaultHttpClient
-
-A default implementation for HttpClient.

--- a/bindings/wasm/audit_trail_wasm/examples/README.md
+++ b/bindings/wasm/audit_trail_wasm/examples/README.md
@@ -1,4 +1,4 @@
-# IOTA Audit Trail WASM Examples
+# IOTA Audit Trails WASM Examples
 
 The examples in this folder demonstrate how to use the `@iota/audit-trail` package.
 

--- a/bindings/wasm/audit_trail_wasm/examples/README.md
+++ b/bindings/wasm/audit_trail_wasm/examples/README.md
@@ -6,12 +6,12 @@ The examples in this folder demonstrate how to use the `@iota/audit-trails` pack
 
 Set the following environment variables before running the node examples:
 
-| Name                        | Required            | Description                                           |
-| --------------------------- | ------------------- | ----------------------------------------------------- |
-| `IOTA_AUDIT_TRAIL_PKG_ID`   | yes                 | Package ID of the deployed `audit_trail` Move package |
-| `IOTA_TF_COMPONENTS_PKG_ID` | local/custom setups | Package ID of the deployed `TfComponents` package     |
-| `NETWORK_URL`               | yes                 | RPC URL of the IOTA node                              |
-| `NETWORK_NAME_FAUCET`       | local/test networks | Faucet alias used by `@iota/iota-sdk`                 |
+| Name                        | Required            | Description                                               |
+|-----------------------------|---------------------|-----------------------------------------------------------|
+| `IOTA_AUDIT_TRAIL_PKG_ID`   | yes                 | Package ID of the deployed `IotaAuditTrails` Move package |
+| `IOTA_TF_COMPONENTS_PKG_ID` | local/custom setups | Package ID of the deployed `TfComponents` package         |
+| `NETWORK_URL`               | yes                 | RPC URL of the IOTA node                                  |
+| `NETWORK_NAME_FAUCET`       | local/test networks | Faucet alias used by `@iota/iota-sdk`                     |
 
 ## Run
 

--- a/bindings/wasm/audit_trail_wasm/examples/README.md
+++ b/bindings/wasm/audit_trail_wasm/examples/README.md
@@ -1,6 +1,6 @@
 # IOTA Audit Trails WASM Examples
 
-The examples in this folder demonstrate how to use the `@iota/audit-trail` package.
+The examples in this folder demonstrate how to use the `@iota/audit-trails` package.
 
 ## Environment
 

--- a/bindings/wasm/audit_trail_wasm/examples/README.md
+++ b/bindings/wasm/audit_trail_wasm/examples/README.md
@@ -7,7 +7,7 @@ The examples in this folder demonstrate how to use the `@iota/audit-trails` pack
 Set the following environment variables before running the node examples:
 
 | Name                        | Required            | Description                                               |
-|-----------------------------|---------------------|-----------------------------------------------------------|
+| --------------------------- | ------------------- | --------------------------------------------------------- |
 | `IOTA_AUDIT_TRAIL_PKG_ID`   | yes                 | Package ID of the deployed `IotaAuditTrails` Move package |
 | `IOTA_TF_COMPONENTS_PKG_ID` | local/custom setups | Package ID of the deployed `TfComponents` package         |
 | `NETWORK_URL`               | yes                 | RPC URL of the IOTA node                                  |

--- a/bindings/wasm/audit_trail_wasm/examples/src/01_create_audit_trail.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/01_create_audit_trail.ts
@@ -15,7 +15,7 @@
  * 3. Define a RecordAdmin role and issue a capability for it.
  */
 
-import { CapabilityIssueOptions, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { createTrailWithSeedRecord, getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/02_add_and_read_records.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/02_add_and_read_records.ts
@@ -14,7 +14,7 @@
  * 3. Paginate through records.
  */
 
-import { CapabilityIssueOptions, Data, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { createTrailWithSeedRecord, getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/03_update_metadata.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/03_update_metadata.ts
@@ -15,7 +15,7 @@
  * 4. Verify that immutable metadata never changes.
  */
 
-import { CapabilityIssueOptions, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/04_configure_locking.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/04_configure_locking.ts
@@ -23,7 +23,7 @@ import {
     LockingWindow,
     PermissionSet,
     TimeLock,
-} from "@iota/audit-trail/node";
+} from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { createTrailWithSeedRecord, getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/05_manage_access.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/05_manage_access.ts
@@ -16,7 +16,7 @@
  * 4. Remove the role after its capabilities are no longer needed.
  */
 
-import { CapabilityIssueOptions, Permission, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Permission, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { createTrailWithSeedRecord, getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/06_delete_records.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/06_delete_records.ts
@@ -14,7 +14,7 @@
  * 3. Delete the remaining records in one batch.
  */
 
-import { CapabilityIssueOptions, Data, Permission, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, Permission, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/07_access_read_only_methods.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/07_access_read_only_methods.ts
@@ -22,7 +22,7 @@ import {
     LockingWindow,
     PermissionSet,
     TimeLock,
-} from "@iota/audit-trail/node";
+} from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/08_delete_audit_trail.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/08_delete_audit_trail.ts
@@ -14,7 +14,7 @@
  * 3. Delete the trail once its records are gone.
  */
 
-import { CapabilityIssueOptions, Data, Permission, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, Permission, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "./util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/advanced/09_tagged_records.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/advanced/09_tagged_records.ts
@@ -16,7 +16,7 @@
  * 4. Show that the holder can add only records matching the allowed tag.
  */
 
-import { CapabilityIssueOptions, Data, Permission, PermissionSet, RoleTags } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, Permission, PermissionSet, RoleTags } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/advanced/10_capability_constraints.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/advanced/10_capability_constraints.ts
@@ -17,7 +17,7 @@
  * 3. Revoke the capability and confirm the bound holder can no longer use it.
  */
 
-import { CapabilityIssueOptions, Data, PermissionSet } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, PermissionSet } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { createTrailWithSeedRecord, getFundedClient, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/advanced/11_manage_record_tags.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/advanced/11_manage_record_tags.ts
@@ -16,7 +16,7 @@
  * 3. Show that tags still in use by roles or records cannot be removed.
  */
 
-import { CapabilityIssueOptions, Data, PermissionSet, RoleTags } from "@iota/audit-trail/node";
+import { CapabilityIssueOptions, Data, PermissionSet, RoleTags } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/real-world/01_customs_clearance.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/real-world/01_customs_clearance.ts
@@ -37,7 +37,7 @@ import {
     LockingWindow,
     PermissionSet,
     TimeLock,
-} from "@iota/audit-trail/node";
+} from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, issueTaggedRecordRole, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/real-world/02_clinical_trial.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/real-world/02_clinical_trial.ts
@@ -40,7 +40,7 @@ import {
     LockingWindow,
     PermissionSet,
     TimeLock,
-} from "@iota/audit-trail/node";
+} from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, issueTaggedRecordRole, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/real-world/03_digital_product_passport.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/real-world/03_digital_product_passport.ts
@@ -44,7 +44,7 @@
  *   1-LCC reward record
  */
 
-import { AuditTrailClient, CapabilityIssueOptions, Data, PermissionSet, RoleTags } from "@iota/audit-trail/node";
+import { AuditTrailClient, CapabilityIssueOptions, Data, PermissionSet, RoleTags } from "@iota/audit-trails/node";
 import { strict as assert } from "assert";
 import { getFundedClient, issueTaggedRecordRole, TEST_GAS_BUDGET } from "../util";
 

--- a/bindings/wasm/audit_trail_wasm/examples/src/util.ts
+++ b/bindings/wasm/audit_trail_wasm/examples/src/util.ts
@@ -12,7 +12,7 @@ import {
     PermissionSet,
     RoleTags,
     TimeLock,
-} from "@iota/audit-trail/node";
+} from "@iota/audit-trails/node";
 import { Ed25519KeypairSigner } from "@iota/iota-interaction-ts/node/test_utils";
 import { IotaClient } from "@iota/iota-sdk/client";
 import { getFaucetHost, requestIotaFromFaucetV0 } from "@iota/iota-sdk/faucet";

--- a/bindings/wasm/audit_trail_wasm/examples/tsconfig.node.json
+++ b/bindings/wasm/audit_trail_wasm/examples/tsconfig.node.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "paths": {
-      "@iota/audit-trail/node": [
+      "@iota/audit-trails/node": [
         "../node"
       ]
     }

--- a/bindings/wasm/audit_trail_wasm/examples/tsconfig.web.json
+++ b/bindings/wasm/audit_trail_wasm/examples/tsconfig.web.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "paths": {
-      "@iota/audit-trail/node": [
+      "@iota/audit-trails/node": [
         "../web"
       ]
     }

--- a/bindings/wasm/audit_trail_wasm/package-lock.json
+++ b/bindings/wasm/audit_trail_wasm/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@iota/audit-trail",
+  "name": "@iota/audit-trails",
   "version": "0.1.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@iota/audit-trail",
+      "name": "@iota/audit-trails",
       "version": "0.1.0-alpha",
       "license": "Apache-2.0",
       "dependencies": {

--- a/bindings/wasm/audit_trail_wasm/package.json
+++ b/bindings/wasm/audit_trail_wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@iota/audit-trail",
+  "name": "@iota/audit-trails",
   "author": "IOTA Foundation <info@iota.org>",
   "description": "WASM bindings for IOTA Audit Trail. To be used in JavaScript/TypeScript.",
   "homepage": "https://www.iota.org",

--- a/bindings/wasm/audit_trail_wasm/src/builder.rs
+++ b/bindings/wasm/audit_trail_wasm/src/builder.rs
@@ -15,9 +15,8 @@ use crate::types::WasmLockingConfig;
 ///
 /// @remarks
 /// The resulting transaction publishes the trail as a *shared* object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
-/// {@link PermissionSet.adminPermissions}, and transfers a freshly minted initial-admin
-/// {@link Capability} to the configured admin address. An
+/// {@link RoleMap.initialAdminRoleName | Admin} role with the recommended admin permissions, and
+/// transfers a freshly minted initial-admin {@link Capability} to the configured admin address. An
 /// admin address must be set (either through {@link AuditTrailBuilder.withAdmin} or by constructing
 /// the builder via {@link AuditTrailClient.createTrail}, which seeds it with the signer); otherwise
 /// {@link AuditTrailBuilder.finish} produces a transaction that fails to build. When an initial
@@ -131,9 +130,8 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the trail's role map is seeded with a single role named `"Admin"` carrying the
-    /// permission set returned by {@link PermissionSet.adminPermissions}, and a freshly minted
-    /// initial-admin capability is transferred to this address. Setting an admin is required before
-    /// {@link AuditTrailBuilder.finish} can
+    /// recommended admin permissions, and a freshly minted initial-admin capability is transferred
+    /// to this address. Setting an admin is required before {@link AuditTrailBuilder.finish} can
     /// produce a viable transaction; constructing the builder via
     /// {@link AuditTrailClient.createTrail} already seeds it with the signer address.
     ///
@@ -152,9 +150,8 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the audit-trail package shares the new trail object, seeds the reserved
-    /// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
-    /// {@link PermissionSet.adminPermissions}, transfers an initial-admin capability to the
-    /// configured admin address, and optionally stores the initial record at sequence number
+    /// {@link RoleMap.initialAdminRoleName | Admin} role, transfers an initial-admin capability to
+    /// the configured admin address, and optionally stores the initial record at sequence number
     /// `0`.
     ///
     /// @returns A {@link TransactionBuilder} wrapping the {@link CreateTrail} transaction.

--- a/bindings/wasm/audit_trail_wasm/src/builder.rs
+++ b/bindings/wasm/audit_trail_wasm/src/builder.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use audit_trail::core::builder::AuditTrailBuilder;
+use audit_trails::core::builder::AuditTrailBuilder;
 use iota_interaction_ts::wasm_error::{Result, WasmResult};
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_iota_address};

--- a/bindings/wasm/audit_trail_wasm/src/builder.rs
+++ b/bindings/wasm/audit_trail_wasm/src/builder.rs
@@ -15,8 +15,9 @@ use crate::types::WasmLockingConfig;
 ///
 /// @remarks
 /// The resulting transaction publishes the trail as a *shared* object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role with the recommended admin permissions, and
-/// transfers a freshly minted initial-admin {@link Capability} to the configured admin address. An
+/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+/// {@link PermissionSet.adminPermissions}, and transfers a freshly minted initial-admin
+/// {@link Capability} to the configured admin address. An
 /// admin address must be set (either through {@link AuditTrailBuilder.withAdmin} or by constructing
 /// the builder via {@link AuditTrailClient.createTrail}, which seeds it with the signer); otherwise
 /// {@link AuditTrailBuilder.finish} produces a transaction that fails to build. When an initial
@@ -130,8 +131,9 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the trail's role map is seeded with a single role named `"Admin"` carrying the
-    /// recommended admin permissions, and a freshly minted initial-admin capability is transferred
-    /// to this address. Setting an admin is required before {@link AuditTrailBuilder.finish} can
+    /// permission set returned by {@link PermissionSet.adminPermissions}, and a freshly minted
+    /// initial-admin capability is transferred to this address. Setting an admin is required before
+    /// {@link AuditTrailBuilder.finish} can
     /// produce a viable transaction; constructing the builder via
     /// {@link AuditTrailClient.createTrail} already seeds it with the signer address.
     ///
@@ -150,8 +152,9 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the audit-trail package shares the new trail object, seeds the reserved
-    /// {@link RoleMap.initialAdminRoleName | Admin} role, transfers an initial-admin capability to
-    /// the configured admin address, and optionally stores the initial record at sequence number
+    /// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+    /// {@link PermissionSet.adminPermissions}, transfers an initial-admin capability to the
+    /// configured admin address, and optionally stores the initial record at sequence number
     /// `0`.
     ///
     /// @returns A {@link TransactionBuilder} wrapping the {@link CreateTrail} transaction.

--- a/bindings/wasm/audit_trail_wasm/src/client.rs
+++ b/bindings/wasm/audit_trail_wasm/src/client.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use audit_trail::{AuditTrailClient, AuditTrailClientReadOnly, PackageOverrides};
+use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly, PackageOverrides};
 use iota_interaction_ts::bindings::{WasmIotaClient, WasmPublicKey, WasmTransactionSigner};
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
 use product_common::bindings::utils::parse_wasm_object_id;

--- a/bindings/wasm/audit_trail_wasm/src/client_read_only.rs
+++ b/bindings/wasm/audit_trail_wasm/src/client_read_only.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use audit_trail::{AuditTrailClientReadOnly, PackageOverrides};
+use audit_trails::{AuditTrailClientReadOnly, PackageOverrides};
 use iota_interaction_ts::bindings::WasmIotaClient;
 use iota_interaction_ts::wasm_error::{Result, WasmResult};
 use product_common::bindings::utils::parse_wasm_object_id;

--- a/bindings/wasm/audit_trail_wasm/src/trail.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail.rs
@@ -1,18 +1,18 @@
 // Copyright 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use audit_trail::core::access::{
+use audit_trails::core::access::{
     CleanupRevokedCapabilities, CreateRole, DeleteRole, DestroyCapability, DestroyInitialAdminCapability,
     IssueCapability, RevokeCapability, RevokeInitialAdminCapability, UpdateRole,
 };
-use audit_trail::core::create::{CreateTrail, TrailCreated};
-use audit_trail::core::locking::{
+use audit_trails::core::create::{CreateTrail, TrailCreated};
+use audit_trails::core::locking::{
     UpdateDeleteRecordWindow, UpdateDeleteTrailLock, UpdateLockingConfig, UpdateWriteLock,
 };
-use audit_trail::core::records::{AddRecord, DeleteRecord, DeleteRecordsBatch};
-use audit_trail::core::tags::{AddRecordTag, RemoveRecordTag};
-use audit_trail::core::trail::{DeleteAuditTrail, Migrate, UpdateMetadata};
-use audit_trail::core::types::{
+use audit_trails::core::records::{AddRecord, DeleteRecord, DeleteRecordsBatch};
+use audit_trails::core::tags::{AddRecordTag, RemoveRecordTag};
+use audit_trails::core::trail::{DeleteAuditTrail, Migrate, UpdateMetadata};
+use audit_trails::core::types::{
     AuditTrailDeleted, CapabilityDestroyed, CapabilityIssued, CapabilityRevoked, OnChainAuditTrail, RecordAdded,
     RecordDeleted, RevokedCapabilitiesCleanedUp, RoleCreated, RoleDeleted, RoleUpdated,
 };

--- a/bindings/wasm/audit_trail_wasm/src/trail.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail.rs
@@ -182,7 +182,8 @@ async fn apply_trail_created(
 ///
 /// @remarks
 /// On execution the audit-trail package shares the new trail object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role, transfers a fresh initial-admin capability to
+/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+/// {@link PermissionSet.adminPermissions}, transfers a fresh initial-admin capability to
 /// the admin address, and optionally stores the initial record at sequence number `0`, validating
 /// its tag against the registry.
 ///

--- a/bindings/wasm/audit_trail_wasm/src/trail.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail.rs
@@ -182,8 +182,7 @@ async fn apply_trail_created(
 ///
 /// @remarks
 /// On execution the audit-trail package shares the new trail object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
-/// {@link PermissionSet.adminPermissions}, transfers a fresh initial-admin capability to
+/// {@link RoleMap.initialAdminRoleName | Admin} role, transfers a fresh initial-admin capability to
 /// the admin address, and optionally stores the initial record at sequence number `0`, validating
 /// its tag against the registry.
 ///

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/access.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/access.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use audit_trail::AuditTrailClient;
+use audit_trails::AuditTrailClient;
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result};

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use audit_trail::{AuditTrailClient, AuditTrailClientReadOnly};
+use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/mod.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/mod.rs
@@ -10,7 +10,7 @@ mod tags;
 
 pub(crate) use access::WasmTrailAccess;
 use anyhow::anyhow;
-use audit_trail::{AuditTrailClient, AuditTrailClientReadOnly};
+use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use audit_trail::core::types::Data as AuditTrailData;
-use audit_trail::{AuditTrailClient, AuditTrailClientReadOnly};
+use audit_trails::core::types::Data as AuditTrailData;
+use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
@@ -126,12 +126,12 @@ impl WasmTrailRecords {
     /// @param cursor - Sequence-number cursor for the page boundary; pass `null` for the first
     /// page and reuse {@link PaginatedRecord.nextCursor} for subsequent pages.
     /// @param limit - Maximum number of records to return; may not exceed the maximum page size defined in the
-    /// Audit Trail Rust crate.
+    /// Audit Trails Rust crate.
     ///
     /// @returns A {@link PaginatedRecord} carrying the loaded records and pagination metadata.
     ///
     /// @throws When the trail object cannot be fetched, a record cannot be deserialized, or
-    /// `limit` exceeds the maximum page size defined in the Audit Trail Rust crate.
+    /// `limit` exceeds the maximum page size defined in the Audit Trails Rust crate.
     #[wasm_bindgen(js_name = listPage)]
     pub async fn list_page(&self, cursor: Option<u64>, limit: usize) -> Result<WasmPaginatedRecord> {
         let page = self

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/tags.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/tags.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use audit_trail::{AuditTrailClient, AuditTrailClientReadOnly};
+use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -292,6 +292,12 @@ impl WasmPermissionSet {
 
     /// Returns the recommended permission set for the reserved initial-admin role.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.AddCapabilities}, {@link Permission.RevokeCapabilities},
+    /// {@link Permission.AddRecordTags}, {@link Permission.DeleteRecordTags},
+    /// {@link Permission.AddRoles}, {@link Permission.UpdateRoles}, {@link Permission.DeleteRoles}
+    /// and {@link Permission.Migrate} permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes role and capability administration.
     #[wasm_bindgen(js_name = adminPermissions)]
     pub fn admin_permissions() -> Self {
@@ -299,6 +305,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRecord}, {@link Permission.DeleteRecord} and
+    /// {@link Permission.CorrectRecord} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes record reads, writes, and deletions.
     #[wasm_bindgen(js_name = recordAdminPermissions)]
@@ -308,6 +318,12 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to administer locking rules.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.UpdateLockingConfig},
+    /// {@link Permission.UpdateLockingConfigForDeleteTrail},
+    /// {@link Permission.UpdateLockingConfigForDeleteRecord} and
+    /// {@link Permission.UpdateLockingConfigForWrite} permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes updates to all locking dimensions.
     #[wasm_bindgen(js_name = lockingAdminPermissions)]
     pub fn locking_admin_permissions() -> Self {
@@ -315,6 +331,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRoles}, {@link Permission.UpdateRoles} and
+    /// {@link Permission.DeleteRoles} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding, updating, and deleting roles.
     #[wasm_bindgen(js_name = roleAdminPermissions)]
@@ -324,6 +344,10 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to issue and revoke capabilities.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.AddCapabilities} and {@link Permission.RevokeCapabilities}
+    /// permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes the capability lifecycle.
     #[wasm_bindgen(js_name = capAdminPermissions)]
     pub fn cap_admin_permissions() -> Self {
@@ -331,6 +355,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.UpdateMetadata} and {@link Permission.DeleteMetadata}
+    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes updating and clearing
     /// `updatableMetadata`.
@@ -340,6 +368,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRecordTags} and {@link Permission.DeleteRecordTags}
+    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding and removing entries from the
     /// trail's record-tag registry.

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -292,12 +292,6 @@ impl WasmPermissionSet {
 
     /// Returns the recommended permission set for the reserved initial-admin role.
     ///
-    /// @remarks
-    /// Includes the {@link Permission.AddCapabilities}, {@link Permission.RevokeCapabilities},
-    /// {@link Permission.AddRecordTags}, {@link Permission.DeleteRecordTags},
-    /// {@link Permission.AddRoles}, {@link Permission.UpdateRoles}, {@link Permission.DeleteRoles}
-    /// and {@link Permission.Migrate} permissions.
-    ///
     /// @returns A {@link PermissionSet} that authorizes role and capability administration.
     #[wasm_bindgen(js_name = adminPermissions)]
     pub fn admin_permissions() -> Self {
@@ -305,10 +299,6 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
-    ///
-    /// @remarks
-    /// Includes the {@link Permission.AddRecord}, {@link Permission.DeleteRecord} and
-    /// {@link Permission.CorrectRecord} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes record reads, writes, and deletions.
     #[wasm_bindgen(js_name = recordAdminPermissions)]
@@ -318,12 +308,6 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to administer locking rules.
     ///
-    /// @remarks
-    /// Includes the {@link Permission.UpdateLockingConfig},
-    /// {@link Permission.UpdateLockingConfigForDeleteTrail},
-    /// {@link Permission.UpdateLockingConfigForDeleteRecord} and
-    /// {@link Permission.UpdateLockingConfigForWrite} permissions.
-    ///
     /// @returns A {@link PermissionSet} that authorizes updates to all locking dimensions.
     #[wasm_bindgen(js_name = lockingAdminPermissions)]
     pub fn locking_admin_permissions() -> Self {
@@ -331,10 +315,6 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
-    ///
-    /// @remarks
-    /// Includes the {@link Permission.AddRoles}, {@link Permission.UpdateRoles} and
-    /// {@link Permission.DeleteRoles} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding, updating, and deleting roles.
     #[wasm_bindgen(js_name = roleAdminPermissions)]
@@ -344,10 +324,6 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to issue and revoke capabilities.
     ///
-    /// @remarks
-    /// Includes the {@link Permission.AddCapabilities} and {@link Permission.RevokeCapabilities}
-    /// permissions.
-    ///
     /// @returns A {@link PermissionSet} that authorizes the capability lifecycle.
     #[wasm_bindgen(js_name = capAdminPermissions)]
     pub fn cap_admin_permissions() -> Self {
@@ -355,10 +331,6 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
-    ///
-    /// @remarks
-    /// Includes the {@link Permission.UpdateMetadata} and {@link Permission.DeleteMetadata}
-    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes updating and clearing
     /// `updatableMetadata`.
@@ -368,10 +340,6 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
-    ///
-    /// @remarks
-    /// Includes the {@link Permission.AddRecordTags} and {@link Permission.DeleteRecordTags}
-    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding and removing entries from the
     /// trail's record-tag registry.

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -171,7 +171,7 @@ fn sorted_role_entries(roles: HashMap<String, Role>) -> Vec<WasmRolePermissionsE
     roles
 }
 
-/// Permission variants enumerated by Audit Trail.
+/// Permission variants enumerated by Audit Trails.
 ///
 /// @remarks
 /// Each variant authorizes one operation on a trail. Variants are grouped by the proposed role

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     AuditTrailCreated, AuditTrailDeleted, Capability, CapabilityAdminPermissions, CapabilityDestroyed,
     CapabilityIssueOptions, CapabilityIssued, CapabilityRevoked, Data, ImmutableMetadata, LockingConfig, LockingWindow,
     PaginatedRecord, Permission, PermissionSet, Record, RecordAdded, RecordCorrection, RecordDeleted,

--- a/bindings/wasm/audit_trail_wasm/tsconfig.json
+++ b/bindings/wasm/audit_trail_wasm/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@iota/audit-trail/*": [
+      "@iota/audit-trails/*": [
         "./*"
       ]
     }

--- a/bindings/wasm/audit_trail_wasm/typedoc.json
+++ b/bindings/wasm/audit_trail_wasm/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "name": "@iota/audit-trail API documentation",
+  "name": "@iota/audit-trails API documentation",
   "extends": [
     "../typedoc.json"
   ],

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -106,7 +106,7 @@ path = "audit-trail/real-world/03_digital_product_passport.rs"
 
 [dependencies]
 anyhow.workspace = true
-audit_trail = { path = "../audit-trail-rs" }
+audit_trails = { path = "../audit-trail-rs" }
 chrono = { workspace = true }
 iota-sdk = { workspace = true }
 notarization = { path = "../notarization-rs" }

--- a/examples/audit-trail/01_create_audit_trail.rs
+++ b/examples/audit-trail/01_create_audit_trail.rs
@@ -7,7 +7,7 @@
 //! - **Record admin client**: Receives a RecordAdmin capability bound to their address so it can write records.
 
 use anyhow::Result;
-use audit_trail::core::types::{CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/02_add_and_read_records.rs
+++ b/examples/audit-trail/02_add_and_read_records.rs
@@ -8,7 +8,7 @@
 //!   the example focused on one trail handle after delegation.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/03_update_metadata.rs
+++ b/examples/audit-trail/03_update_metadata.rs
@@ -8,7 +8,7 @@
 //!   record-write permissions.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/04_configure_locking.rs
+++ b/examples/audit-trail/04_configure_locking.rs
@@ -9,7 +9,7 @@
 //!   checked by the admin.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, LockingWindow, PermissionSet, TimeLock};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, LockingWindow, PermissionSet, TimeLock};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/05_manage_access.rs
+++ b/examples/audit-trail/05_manage_access.rs
@@ -11,7 +11,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, Permission, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, Permission, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
 
     let created_trail = admin_client
         .create_trail()
-        .with_initial_record(audit_trail::core::types::InitialRecord::new(
+        .with_initial_record(audit_trails::core::types::InitialRecord::new(
             Data::text("Trail created"),
             None,
             None,

--- a/examples/audit-trail/06_delete_records.rs
+++ b/examples/audit-trail/06_delete_records.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/07_access_read_only_methods.rs
+++ b/examples/audit-trail/07_access_read_only_methods.rs
@@ -8,7 +8,7 @@
 //!   by any address — no capability required.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, PermissionSet,
     TimeLock,
 };

--- a/examples/audit-trail/08_delete_audit_trail.rs
+++ b/examples/audit-trail/08_delete_audit_trail.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/README.md
+++ b/examples/audit-trail/README.md
@@ -1,6 +1,6 @@
-# IOTA Audit Trail Examples
+# IOTA Audit Trails Examples
 
-The following code examples demonstrate how to use IOTA Audit Trail for creating structured, role-based audit logs on the IOTA network.
+The following code examples demonstrate how to use IOTA Audit Trails for creating structured, role-based audit logs on the IOTA network.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ Examples can be run against:
 - A local IOTA node
 - An existing network, e.g., the IOTA testnet
 
-When setting up a local node, you'll need to publish an Audit Trail Package as described in the IOTA documentation. You'll also need to provide environment variables for your locally deployed Audit Trail Package to run the examples against the local node.
+When setting up a local node, you'll need to publish an Audit Trails Package as described in the IOTA documentation. You'll also need to provide environment variables for your locally deployed Audit Trails Package to run the examples against the local node.
 
 If running the examples on `testnet`, use the appropriate package IDs for the testnet deployment.
 
@@ -25,7 +25,7 @@ You'll need one or more of the following environment variables depending on your
 | IOTA_TF_COMPONENTS_PKG_ID |            x            |                      |                         |
 | API_ENDPOINT              |                         |          x           |            x            |
 
-> **Note:** On localnet both `IOTA_AUDIT_TRAIL_PKG_ID` and `IOTA_TF_COMPONENTS_PKG_ID` resolve to the same package ID because the TfComponents dependency is published together with the Audit Trail Package.
+> **Note:** On localnet both `IOTA_AUDIT_TRAIL_PKG_ID` and `IOTA_TF_COMPONENTS_PKG_ID` resolve to the same package ID because the TfComponents dependency is published together with the Audit Trails Package.
 
 ## Running Examples
 
@@ -85,7 +85,7 @@ IOTA_AUDIT_TRAIL_PKG_ID=0x... IOTA_TF_COMPONENTS_PKG_ID=0x... cargo run --releas
 
 ## Key Concepts
 
-### Audit Trail
+### Audit Trails
 
 An audit trail is an on-chain object that stores an ordered sequence of records. Each trail has:
 
@@ -167,4 +167,4 @@ Trails support three independent lock dimensions:
 - Delete-trail locks ensure data retention requirements are met
 - Revoking a capability adds it to the trail's revoked-capability registry, blocking future use
 
-For more detailed information about IOTA Audit Trail concepts and advanced usage, refer to the official IOTA documentation.
+For more detailed information about IOTA Audit Trails concepts and advanced usage, refer to the official IOTA documentation.

--- a/examples/audit-trail/advanced/09_tagged_records.rs
+++ b/examples/audit-trail/advanced/09_tagged_records.rs
@@ -9,7 +9,7 @@
 //!   from writing `legal`-tagged records.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, RoleTags};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, Permission, RoleTags};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
         .access()
         .for_role(finance_writer_role)
         .create(
-            audit_trail::core::types::PermissionSet {
+            audit_trails::core::types::PermissionSet {
                 permissions: [Permission::AddRecord].into_iter().collect(),
             },
             Some(RoleTags::new(["finance"])),

--- a/examples/audit-trail/advanced/10_capability_constraints.rs
+++ b/examples/audit-trail/advanced/10_capability_constraints.rs
@@ -11,7 +11,7 @@
 //!   attempts are rejected by the Move contract.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/advanced/11_manage_record_tags.rs
+++ b/examples/audit-trail/advanced/11_manage_record_tags.rs
@@ -9,7 +9,7 @@
 //!   keeps the `finance` tag in use and therefore unremovable.
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet, RoleTags};
+use audit_trails::core::types::{CapabilityIssueOptions, Data, InitialRecord, PermissionSet, RoleTags};
 use examples::get_funded_audit_trail_client;
 use product_common::core_client::CoreClient;
 

--- a/examples/audit-trail/real-world/01_customs_clearance.rs
+++ b/examples/audit-trail/real-world/01_customs_clearance.rs
@@ -28,7 +28,7 @@
 //! - locking: writes are frozen once the shipment is fully cleared
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, PermissionSet,
     TimeLock,
 };

--- a/examples/audit-trail/real-world/02_clinical_trial.rs
+++ b/examples/audit-trail/real-world/02_clinical_trial.rs
@@ -32,7 +32,7 @@
 //! - read-only verification: a regulator inspects the trail without write access
 
 use anyhow::{Result, ensure};
-use audit_trail::core::types::{
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, LockingConfig, LockingWindow, PermissionSet,
     TimeLock,
 };

--- a/examples/audit-trail/real-world/03_digital_product_passport.rs
+++ b/examples/audit-trail/real-world/03_digital_product_passport.rs
@@ -37,8 +37,8 @@
 //!   76% health score and a 1-LCC reward record
 
 use anyhow::{Result, ensure};
-use audit_trail::AuditTrailClient;
-use audit_trail::core::types::{
+use audit_trails::AuditTrailClient;
+use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet, RoleTags,
 };
 use examples::{get_funded_audit_trail_client, issue_tagged_record_role};

--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
-use audit_trail::core::types::{CapabilityIssueOptions, PermissionSet, RoleTags};
-use audit_trail::{AuditTrailClient, PackageOverrides};
+use audit_trails::core::types::{CapabilityIssueOptions, PermissionSet, RoleTags};
+use audit_trails::{AuditTrailClient, PackageOverrides};
 use iota_sdk::types::base_types::{IotaAddress, ObjectID};
 use iota_sdk::{IOTA_LOCAL_NETWORK_URL, IotaClientBuilder};
 use notarization::client::{NotarizationClient, NotarizationClientReadOnly};

--- a/notarization-rs/README.md
+++ b/notarization-rs/README.md
@@ -8,7 +8,7 @@ notarization objects. The builder returns a `Notarization` struct instance that 
 typed methods for interacting with it.
 
 Use Single Notarization when you need one notarized object for arbitrary data, documents, hashes, or latest-state
-records. Use Audit Trail when you need a structured record history with roles, capabilities, locking, and tagging.
+records. Use Audit Trails when you need a structured record history with roles, capabilities, locking, and tagging.
 
 You can find the full IOTA Notarization Toolkit documentation [here](https://docs.iota.org/developer/iota-notarization).
 


### PR DESCRIPTION
# Description of change

The product name `Audit Trail` has changed to `Audit Trails`.

In this context Following changes are included in this PR:
* `Naming Conventions` section in the `CLAUDE.md` file has been changed accordingly
* README files and source docs of public exposed entities for Move, Rust and WASM/TS have been checked and edited according to the new `Naming Conventions`
* Audit Trails Move package:
   * The name of the package has been renamed to `IotaAuditTrails`
   * The alias of the package address has been renamed to `audit_trails` allowing Move users to import AT Move types with `use audit_trails:: ...`
* The npmjs package "@iota/audit-trail" has been renamed to "@iota/audit-trails"
* The Rust crate `audit_trail` has been renamed to `audit_trails` - folder names are kept as-is. This allow Rust users to import the crate using `use audit_trails::...`  instead of `use audit_trail::....`

Some additional minor changes:
* The `Permission::Migrate`has been added to the `admin_permissions()` set in the AT Rust package
* The `audit/trail_wasm/docs` folder has been deleted because it's auto generated and contained in `.gitignore`
* Use qualified type names for events and errors originating from TfComponents used in `audit-trail-move/sources/audit_trail.move`

Files, folders, crates, modules (Rust, Move) etc. still strictly follow the "only singular form in names rule". Only renaming the crate and the npmjs package allows users to have proper imports in TS and Rust but doesn't cause too much efforts.