### PR TITLE
Enhanced permission set docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ client
     .await?;
 ```
 
-`PermissionSet` convenience constructors: `admin_permissions()`, `record_admin_permissions()`, `locking_admin_permissions()`, `tag_admin_permissions()`, `cap_admin_permissions()`, `metadata_admin_permissions()`.
+`PermissionSet` convenience constructors: `admin_permissions()`, `record_admin_permissions()`, `role_admin_permissions()`, `locking_admin_permissions()`, `tag_admin_permissions()`, `cap_admin_permissions()`, `metadata_admin_permissions()`.
 
 **Issuing a capability** — mint a capability object for a role:
 

--- a/audit-trail-move/sources/audit_trail.move
+++ b/audit-trail-move/sources/audit_trail.move
@@ -160,10 +160,9 @@ public fun new_trail_metadata(name: String, description: Option<String>): Immuta
 /// Creates a new audit trail with an optional initial record and shares it on-chain.
 ///
 /// Initialises the trail's role map with a single role named "Admin" associated with
-/// the permissions `DeleteAuditTrail`, `AddCapabilities`, `RevokeCapabilities`,
-/// `AddRoles`, `UpdateRoles` and `DeleteRoles`. The creator receives an initial admin
-/// capability that may be used to define further roles and to issue capabilities to
-/// other users.
+/// the permission set defined by the `permission::admin_permissions()` function. The
+/// creator receives an initial admin capability that may be used to define further
+/// roles and to issue capabilities to other users.
 ///
 /// When `initial_record` is provided it is stored at sequence number `0`; otherwise
 /// the trail is created empty. If the initial record carries a tag, that tag must

--- a/audit-trail-move/sources/permission.move
+++ b/audit-trail-move/sources/permission.move
@@ -94,9 +94,19 @@ public fun has_permission(set: &VecSet<Permission>, perm: &Permission): bool {
     vec_set::contains(set, perm)
 }
 
-// ------Functions creating permission sets for often used roles ---------
+// ------ Functions creating permission sets for often used roles ---------
 
-/// Create permissions typically used for the `Admin` role
+/// Creates the permission set typically used for the `Admin` role.
+///
+/// Includes the following permissions:
+/// * `AddCapabilities`
+/// * `RevokeCapabilities`
+/// * `AddRecordTags`
+/// * `DeleteRecordTags`
+/// * `AddRoles`
+/// * `UpdateRoles`
+/// * `DeleteRoles`
+/// * `Migrate`
 public fun admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -110,7 +120,12 @@ public fun admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `RecordAdmin` role
+/// Creates the permission set typically used for the `RecordAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRecord`
+/// * `DeleteRecord`
+/// * `CorrectRecord`
 public fun record_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record());
@@ -119,7 +134,13 @@ public fun record_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `LockingAdmin` role
+/// Creates the permission set typically used for the `LockingAdmin` role.
+///
+/// Includes the following permissions:
+/// * `UpdateLockingConfig`
+/// * `UpdateLockingConfigForDeleteTrail`
+/// * `UpdateLockingConfigForDeleteRecord`
+/// * `UpdateLockingConfigForWrite`
 public fun locking_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_locking_config());
@@ -129,7 +150,12 @@ public fun locking_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `RoleAdmin` role
+/// Creates the permission set typically used for the `RoleAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRoles`
+/// * `UpdateRoles`
+/// * `DeleteRoles`
 public fun role_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_roles());
@@ -138,7 +164,11 @@ public fun role_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typically used for the `TagAdmin` role
+/// Creates the permission set typically used for the `TagAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddRecordTags`
+/// * `DeleteRecordTags`
 public fun tag_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_record_tags());
@@ -146,7 +176,11 @@ public fun tag_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `CapAdmin` role
+/// Creates the permission set typically used for the `CapAdmin` role.
+///
+/// Includes the following permissions:
+/// * `AddCapabilities`
+/// * `RevokeCapabilities`
 public fun cap_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(add_capabilities());
@@ -154,7 +188,11 @@ public fun cap_admin_permissions(): VecSet<Permission> {
     perms
 }
 
-/// Create permissions typical used for the `MetadataAdmin` role
+/// Creates the permission set typically used for the `MetadataAdmin` role.
+///
+/// Includes the following permissions:
+/// * `UpdateMetadata`
+/// * `DeleteMetadata`
 public fun metadata_admin_permissions(): VecSet<Permission> {
     let mut perms = vec_set::empty();
     perms.insert(update_metadata());

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -118,10 +118,10 @@ impl AuditTrailBuilder {
     /// Finalizes the builder and creates the trail-creation transaction builder.
     ///
     /// Validates the configured [`LockingConfig`] before returning the transaction. Currently this rejects:
-    /// - [`LockingWindow::CountBased`](super::types::LockingWindow::CountBased) with `count == 0` (mirrors the
-    ///   Move `ECountWindowMustBePositive` abort).
-    /// - [`TimeLock::UntilDestroyed`](super::types::TimeLock::UntilDestroyed) used as `delete_trail_lock` (mirrors
-    ///   the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    /// - [`LockingWindow::CountBased`](super::types::LockingWindow::CountBased) with `count == 0` (mirrors the Move
+    ///   `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`](super::types::TimeLock::UntilDestroyed) used as `delete_trail_lock` (mirrors the
+    ///   Move `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/builder.rs
+++ b/audit-trail-rs/src/core/builder.rs
@@ -118,9 +118,10 @@ impl AuditTrailBuilder {
     /// Finalizes the builder and creates the trail-creation transaction builder.
     ///
     /// Validates the configured [`LockingConfig`] before returning the transaction. Currently this rejects:
-    /// - [`LockingWindow::CountBased`] with `count == 0` (mirrors the Move `ECountWindowMustBePositive` abort).
-    /// - [`TimeLock::UntilDestroyed`] used as `delete_trail_lock` (mirrors the Move
-    ///   `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
+    /// - [`LockingWindow::CountBased`](super::types::LockingWindow::CountBased) with `count == 0` (mirrors the
+    ///   Move `ECountWindowMustBePositive` abort).
+    /// - [`TimeLock::UntilDestroyed`](super::types::TimeLock::UntilDestroyed) used as `delete_trail_lock` (mirrors
+    ///   the Move `EUntilDestroyedNotSupportedForDeleteTrail` abort). `write_lock` may still be `UntilDestroyed`.
     ///
     /// # Errors
     ///

--- a/audit-trail-rs/src/core/types/RoleMap-README.md
+++ b/audit-trail-rs/src/core/types/RoleMap-README.md
@@ -18,12 +18,12 @@ validates the capability before allowing the operation.
 
 A role is a named and configurable set of `Permission` values, for example:
 
-| Role name      | Permissions                                                                                              |
-| :------------- | :------------------------------------------------------------------------------------------------------- |
-| `Admin`        | AddRoles, UpdateRoles, DeleteRoles, AddCapabilities, RevokeCapabilities, AddRecordTags, DeleteRecordTags |
-| `RecordAdmin`  | AddRecord, DeleteRecord, CorrectRecord                                                                   |
-| `LockingAdmin` | UpdateLockingConfig (and sub-variants)                                                                   |
-| `Auditor`      | _(read-only — no write permissions needed)_                                                              |
+| Role name      | Permissions                                       |
+|:---------------|:--------------------------------------------------|
+| `Admin`        | the set returned by `admin_permissions()`         |
+| `RecordAdmin`  | the set returned by `record_admin_permissions()`  |
+| `LockingAdmin` | the set returned by `locking_admin_permissions()` |
+| `Auditor`      | _(read-only — no write permissions needed)_       |
 
 Roles are identified by a unique string name within the trail. Multiple
 capabilities can be issued for the same role, to allow users or services to share
@@ -56,10 +56,10 @@ supplied via `with_admin`).
 The Admin role is protected by two invariants:
 
 1. It can **never be deleted**.
-2. Although its permission set can be updated, it needs to include a minimum set of
-   permissions to manage the trail's access control (AddRoles, UpdateRoles, DeleteRoles,
-   AddCapabilities, RevokeCapabilities). Removing any of these permissions from the Admin
-   role will fail.
+2. Although its permission set can be updated, it must always retain the permissions required
+   to manage the trail's access control — those returned by `role_admin_permissions()` (role
+   management) together with those returned by `cap_admin_permissions()` (capability
+   management). Removing any of these permissions from the Admin role will fail.
 
 Initial admin capabilities are tracked in `initial_admin_cap_ids` and must be
 managed through dedicated entry-points (`revoke_initial_admin_capability`,
@@ -75,7 +75,7 @@ managed through dedicated entry-points (`revoke_initial_admin_capability`,
 Trail creator  ──create_trail()──►  AuditTrail (shared object)
                                          │
                                          └── RoleMap
-                                               ├── roles: { "Admin" → [AddRoles, …] }
+                                               ├── roles: { "Admin" → admin_permissions() }
                                                ├── initial_admin_role_name: "Admin"
                                                └── initial_admin_cap_ids: { cap_id }
                     ◄── Admin Capability (owned object, transferred to creator)
@@ -86,8 +86,8 @@ Trail creator  ──create_trail()──►  AuditTrail (shared object)
 The trail creator (Admin capability holder) defines a `RecordAdmin` role:
 
 ```
-Admin Capability + create_role("RecordAdmin", [AddRecord, DeleteRecord, CorrectRecord])
-    ──►  RoleMap.roles: { "Admin" → […], "RecordAdmin" → [AddRecord, DeleteRecord, CorrectRecord] }
+Admin Capability + create_role("RecordAdmin", record_admin_permissions())
+    ──►  RoleMap.roles: { "Admin" → admin_permissions(), "RecordAdmin" → record_admin_permissions() }
 ```
 
 ### 3 — Admin issues capabilities to operators
@@ -509,16 +509,19 @@ permission.
 
 ## Permission Sets
 
-`PermissionSet` provides convenience constructors for common role profiles:
+`PermissionSet` provides convenience constructors for common role profiles. The exact
+permissions each one grants are documented on the function itself (the source of truth); the
+table below only summarizes the role each profile targets:
 
-| Constructor                    | Permissions                                                                                              |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------- |
-| `admin_permissions()`          | AddRoles, UpdateRoles, DeleteRoles, AddCapabilities, RevokeCapabilities, AddRecordTags, DeleteRecordTags |
-| `record_admin_permissions()`   | AddRecord, DeleteRecord, CorrectRecord                                                                   |
-| `locking_admin_permissions()`  | UpdateLockingConfig (and all sub-variants)                                                               |
-| `cap_admin_permissions()`      | AddCapabilities, RevokeCapabilities                                                                      |
-| `tag_admin_permissions()`      | AddRecordTags, DeleteRecordTags                                                                          |
-| `metadata_admin_permissions()` | UpdateMetadata, DeleteMetadata                                                                           |
+| Constructor                    | Intended role                               |
+|:-------------------------------|:--------------------------------------------|
+| `admin_permissions()`          | `Admin` — full trail administration         |
+| `record_admin_permissions()`   | record management (add, delete, correct)    |
+| `role_admin_permissions()`     | role management (add, update, delete roles) |
+| `locking_admin_permissions()`  | locking-configuration management            |
+| `cap_admin_permissions()`      | capability management (issue, revoke)       |
+| `tag_admin_permissions()`      | record-tag registry management              |
+| `metadata_admin_permissions()` | updatable-metadata management               |
 
 Please note:
 

--- a/audit-trail-rs/src/core/types/RoleMap-README.md
+++ b/audit-trail-rs/src/core/types/RoleMap-README.md
@@ -19,7 +19,7 @@ validates the capability before allowing the operation.
 A role is a named and configurable set of `Permission` values, for example:
 
 | Role name      | Permissions                                       |
-|:---------------|:--------------------------------------------------|
+| :------------- | :------------------------------------------------ |
 | `Admin`        | the set returned by `admin_permissions()`         |
 | `RecordAdmin`  | the set returned by `record_admin_permissions()`  |
 | `LockingAdmin` | the set returned by `locking_admin_permissions()` |
@@ -514,7 +514,7 @@ permissions each one grants are documented on the function itself (the source of
 table below only summarizes the role each profile targets:
 
 | Constructor                    | Intended role                               |
-|:-------------------------------|:--------------------------------------------|
+| :----------------------------- | :------------------------------------------ |
 | `admin_permissions()`          | `Admin` — full trail administration         |
 | `record_admin_permissions()`   | record management (add, delete, correct)    |
 | `role_admin_permissions()`     | role management (add, update, delete roles) |

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -128,6 +128,16 @@ impl PermissionSet {
     }
     /// Returns the recommended permission set for the `Admin` role.
     ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddCapabilities`]
+    /// - [`Permission::RevokeCapabilities`]
+    /// - [`Permission::AddRecordTags`]
+    /// - [`Permission::DeleteRecordTags`]
+    /// - [`Permission::AddRoles`]
+    /// - [`Permission::UpdateRoles`]
+    /// - [`Permission::DeleteRoles`]
+    /// - [`Permission::Migrate`]
+    ///
     /// Mirrors `audit_trail::permission::admin_permissions` in the Move
     /// package. This is the same set the package seeds when a trail is
     /// created and the initial-admin capability is minted.
@@ -146,6 +156,11 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRecord`]
+    /// - [`Permission::DeleteRecord`]
+    /// - [`Permission::CorrectRecord`]
     pub fn record_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -157,6 +172,12 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer locking rules.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::UpdateLockingConfig`]
+    /// - [`Permission::UpdateLockingConfigForDeleteTrail`]
+    /// - [`Permission::UpdateLockingConfigForDeleteRecord`]
+    /// - [`Permission::UpdateLockingConfigForWrite`]
     pub fn locking_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([
@@ -169,6 +190,11 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRoles`]
+    /// - [`Permission::UpdateRoles`]
+    /// - [`Permission::DeleteRoles`]
     pub fn role_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRoles, Permission::UpdateRoles, Permission::DeleteRoles]),
@@ -176,6 +202,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddRecordTags`]
+    /// - [`Permission::DeleteRecordTags`]
     pub fn tag_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from([Permission::AddRecordTags, Permission::DeleteRecordTags]),
@@ -183,6 +213,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to issue and revoke capabilities.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::AddCapabilities`]
+    /// - [`Permission::RevokeCapabilities`]
     pub fn cap_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::AddCapabilities, Permission::RevokeCapabilities]),
@@ -190,6 +224,10 @@ impl PermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
+    ///
+    /// Includes the following permissions:
+    /// - [`Permission::UpdateMetadata`]
+    /// - [`Permission::DeleteMetadata`]
     pub fn metadata_admin_permissions() -> Self {
         Self {
             permissions: HashSet::from_iter(vec![Permission::UpdateMetadata, Permission::DeleteMetadata]),

--- a/bindings/wasm/audit_trail_wasm/src/builder.rs
+++ b/bindings/wasm/audit_trail_wasm/src/builder.rs
@@ -15,8 +15,9 @@ use crate::types::WasmLockingConfig;
 ///
 /// @remarks
 /// The resulting transaction publishes the trail as a *shared* object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role with the recommended admin permissions, and
-/// transfers a freshly minted initial-admin {@link Capability} to the configured admin address. An
+/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+/// {@link PermissionSet.adminPermissions}, and transfers a freshly minted initial-admin
+/// {@link Capability} to the configured admin address. An
 /// admin address must be set (either through {@link AuditTrailBuilder.withAdmin} or by constructing
 /// the builder via {@link AuditTrailClient.createTrail}, which seeds it with the signer); otherwise
 /// {@link AuditTrailBuilder.finish} produces a transaction that fails to build. When an initial
@@ -130,8 +131,9 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the trail's role map is seeded with a single role named `"Admin"` carrying the
-    /// recommended admin permissions, and a freshly minted initial-admin capability is transferred
-    /// to this address. Setting an admin is required before {@link AuditTrailBuilder.finish} can
+    /// permission set returned by {@link PermissionSet.adminPermissions}, and a freshly minted
+    /// initial-admin capability is transferred to this address. Setting an admin is required before
+    /// {@link AuditTrailBuilder.finish} can
     /// produce a viable transaction; constructing the builder via
     /// {@link AuditTrailClient.createTrail} already seeds it with the signer address.
     ///
@@ -150,8 +152,9 @@ impl WasmAuditTrailBuilder {
     ///
     /// @remarks
     /// On execution the audit-trail package shares the new trail object, seeds the reserved
-    /// {@link RoleMap.initialAdminRoleName | Admin} role, transfers an initial-admin capability to
-    /// the configured admin address, and optionally stores the initial record at sequence number
+    /// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+    /// {@link PermissionSet.adminPermissions}, transfers an initial-admin capability to the
+    /// configured admin address, and optionally stores the initial record at sequence number
     /// `0`.
     ///
     /// @returns A {@link TransactionBuilder} wrapping the {@link CreateTrail} transaction.

--- a/bindings/wasm/audit_trail_wasm/src/trail.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail.rs
@@ -182,7 +182,8 @@ async fn apply_trail_created(
 ///
 /// @remarks
 /// On execution the audit-trail package shares the new trail object, seeds the reserved
-/// {@link RoleMap.initialAdminRoleName | Admin} role, transfers a fresh initial-admin capability to
+/// {@link RoleMap.initialAdminRoleName | Admin} role with the permission set returned by
+/// {@link PermissionSet.adminPermissions}, transfers a fresh initial-admin capability to
 /// the admin address, and optionally stores the initial record at sequence number `0`, validating
 /// its tag against the registry.
 ///

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -292,6 +292,12 @@ impl WasmPermissionSet {
 
     /// Returns the recommended permission set for the reserved initial-admin role.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.AddCapabilities}, {@link Permission.RevokeCapabilities},
+    /// {@link Permission.AddRecordTags}, {@link Permission.DeleteRecordTags},
+    /// {@link Permission.AddRoles}, {@link Permission.UpdateRoles}, {@link Permission.DeleteRoles}
+    /// and {@link Permission.Migrate} permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes role and capability administration.
     #[wasm_bindgen(js_name = adminPermissions)]
     pub fn admin_permissions() -> Self {
@@ -299,6 +305,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer records.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRecord}, {@link Permission.DeleteRecord} and
+    /// {@link Permission.CorrectRecord} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes record reads, writes, and deletions.
     #[wasm_bindgen(js_name = recordAdminPermissions)]
@@ -308,6 +318,12 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to administer locking rules.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.UpdateLockingConfig},
+    /// {@link Permission.UpdateLockingConfigForDeleteTrail},
+    /// {@link Permission.UpdateLockingConfigForDeleteRecord} and
+    /// {@link Permission.UpdateLockingConfigForWrite} permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes updates to all locking dimensions.
     #[wasm_bindgen(js_name = lockingAdminPermissions)]
     pub fn locking_admin_permissions() -> Self {
@@ -315,6 +331,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer roles.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRoles}, {@link Permission.UpdateRoles} and
+    /// {@link Permission.DeleteRoles} permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding, updating, and deleting roles.
     #[wasm_bindgen(js_name = roleAdminPermissions)]
@@ -324,6 +344,10 @@ impl WasmPermissionSet {
 
     /// Returns the permissions needed to issue and revoke capabilities.
     ///
+    /// @remarks
+    /// Includes the {@link Permission.AddCapabilities} and {@link Permission.RevokeCapabilities}
+    /// permissions.
+    ///
     /// @returns A {@link PermissionSet} that authorizes the capability lifecycle.
     #[wasm_bindgen(js_name = capAdminPermissions)]
     pub fn cap_admin_permissions() -> Self {
@@ -331,6 +355,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer mutable metadata.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.UpdateMetadata} and {@link Permission.DeleteMetadata}
+    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes updating and clearing
     /// `updatableMetadata`.
@@ -340,6 +368,10 @@ impl WasmPermissionSet {
     }
 
     /// Returns the permissions needed to administer record tags.
+    ///
+    /// @remarks
+    /// Includes the {@link Permission.AddRecordTags} and {@link Permission.DeleteRecordTags}
+    /// permissions.
     ///
     /// @returns A {@link PermissionSet} that authorizes adding and removing entries from the
     /// trail's record-tag registry.

--- a/examples/audit-trail/README.md
+++ b/examples/audit-trail/README.md
@@ -99,22 +99,24 @@ An audit trail is an on-chain object that stores an ordered sequence of records.
 
 Access to trail operations is controlled via roles and capabilities:
 
-- **Roles** define a named set of permissions (e.g., `RecordAdmin` with `AddRecord`, `DeleteRecord`, `CorrectRecord`)
+- **Roles** define a named set of permissions (e.g., a `RecordAdmin` role granting the permissions from `record_admin_permissions()`)
 - **Capabilities** are on-chain objects issued for a role and held in a wallet — possession of a capability grants the associated permissions on a specific trail
 - The trail creator automatically receives an **Admin** capability granting full administrative control (role management, capability issuance, tag management, etc.)
 
 ### Permission Sets
 
-`PermissionSet` convenience constructors cover common role configurations:
+`PermissionSet` convenience constructors cover common role configurations. Each constructor's
+API documentation lists the exact permissions it grants (the source of truth):
 
-| Constructor                    | Permissions granted                                                                                      |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------- |
-| `admin_permissions()`          | AddRoles, UpdateRoles, DeleteRoles, AddCapabilities, RevokeCapabilities, AddRecordTags, DeleteRecordTags |
-| `record_admin_permissions()`   | AddRecord, DeleteRecord, CorrectRecord                                                                   |
-| `locking_admin_permissions()`  | UpdateLockingConfig (and all sub-variants)                                                               |
-| `cap_admin_permissions()`      | AddCapabilities, RevokeCapabilities                                                                      |
-| `tag_admin_permissions()`      | AddRecordTags, DeleteRecordTags                                                                          |
-| `metadata_admin_permissions()` | UpdateMetadata, DeleteMetadata                                                                           |
+| Constructor                    | Intended role                               |
+|:-------------------------------|:--------------------------------------------|
+| `admin_permissions()`          | `Admin` — full trail administration         |
+| `record_admin_permissions()`   | record management (add, delete, correct)    |
+| `role_admin_permissions()`     | role management (add, update, delete roles) |
+| `locking_admin_permissions()`  | locking-configuration management            |
+| `cap_admin_permissions()`      | capability management (issue, revoke)       |
+| `tag_admin_permissions()`      | record-tag registry management              |
+| `metadata_admin_permissions()` | updatable-metadata management               |
 
 ### Capability Constraints
 

--- a/examples/audit-trail/README.md
+++ b/examples/audit-trail/README.md
@@ -109,7 +109,7 @@ Access to trail operations is controlled via roles and capabilities:
 API documentation lists the exact permissions it grants (the source of truth):
 
 | Constructor                    | Intended role                               |
-|:-------------------------------|:--------------------------------------------|
+| :----------------------------- | :------------------------------------------ |
 | `admin_permissions()`          | `Admin` — full trail administration         |
 | `record_admin_permissions()`   | record management (add, delete, correct)    |
 | `role_admin_permissions()`     | role management (add, update, delete roles) |


### PR DESCRIPTION
# Description of change

The docs of all `permission_set` constructor functions (Move, Rust, WASM) now explicitly list the contained permissions and can now be used as source of truth everywhere else.

Several docs contained hard coded permission lists that duplicated the source-of-truth. Three of them were already outdated (i.e. admin_permissions()) and there is a risk that these lists get outdated.

Now the `permission_set` constructor functions are referenced in all other docs (single source of truth - at least in the specific programming language).