### PR TITLE
Release: Audit Trails Version 0.1.1 and npmjs version 0.1.1

### DIFF
--- a/audit-trail-rs/Cargo.toml
+++ b/audit-trail-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit_trails"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/bindings/wasm/audit_trail_wasm/Cargo.toml
+++ b/bindings/wasm/audit_trail_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit_trail_wasm"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/audit_trail_wasm/package-lock.json
+++ b/bindings/wasm/audit_trail_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iota/audit-trails",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iota/audit-trails",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@iota/iota-interaction-ts": "^0.14.0"

--- a/bindings/wasm/audit_trail_wasm/package.json
+++ b/bindings/wasm/audit_trail_wasm/package.json
@@ -3,7 +3,7 @@
   "author": "IOTA Foundation <info@iota.org>",
   "description": "WASM bindings for IOTA Audit Trail. To be used in JavaScript/TypeScript.",
   "homepage": "https://www.iota.org",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Bump cargo versions for Audit Trails packages to 0.1.1
* Bump npmjs version for @iota/audit-trails to 0.1.1