### PR TITLE
feat: Update to iota v1.25.0 - Tests with product-core upstream-merge feature branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ chrono = { version = "0.4", default-features = false }
 hyper = "1"
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.25.0" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false, package = "product_common" }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde-aux = { version = "4.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", default-features = false }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.24.0" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false, package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false, package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false, package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false, package = "product_common" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.25.0" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false, package = "product_common" }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde-aux = { version = "4.7.0", default-features = false }

--- a/audit-trail-rs/Cargo.toml
+++ b/audit-trail-rs/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", default-features = false, features = ["iota"], optional = true }
+iota-sdk-types.workspace = true
 iota_interaction = { workspace = true, default-features = false }
 product_common = { workspace = true, default-features = false, features = ["transaction"] }
 secret-storage = { workspace = true, default-features = false }

--- a/audit-trail-rs/src/client/full_client.rs
+++ b/audit-trail-rs/src/client/full_client.rs
@@ -82,12 +82,13 @@ use std::ops::Deref;
 use async_trait::async_trait;
 #[cfg(not(target_arch = "wasm32"))]
 use iota_interaction::IotaClient;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::crypto::PublicKey;
 use iota_interaction::types::transaction::ProgrammableTransaction;
 use iota_interaction::{IotaKeySignature, OptionalSync};
 #[cfg(target_arch = "wasm32")]
 use iota_interaction_ts::bindings::WasmIotaClient as IotaClient;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::network_name::NetworkName;
 use secret_storage::Signer;
@@ -249,12 +250,12 @@ impl<S> AuditTrailClient<S> {
     }
 
     /// Returns a typed handle bound to a specific trail object ID.
-    pub fn trail<'a>(&'a self, trail_id: ObjectID) -> AuditTrailHandle<'a, Self> {
+    pub fn trail<'a>(&'a self, trail_id: ObjectId) -> AuditTrailHandle<'a, Self> {
         AuditTrailHandle::new(self, trail_id)
     }
 
     /// Returns the TfComponents package ID used by this client.
-    pub fn tf_components_package_id(&self) -> ObjectID {
+    pub fn tf_components_package_id(&self) -> ObjectId {
         self.read_client.tf_components_package_id()
     }
 
@@ -289,11 +290,11 @@ where
 #[cfg_attr(feature = "send-sync", async_trait)]
 #[cfg_attr(not(feature = "send-sync"), async_trait(?Send))]
 impl<S> CoreClientReadOnly for AuditTrailClient<S> {
-    fn package_id(&self) -> ObjectID {
+    fn package_id(&self) -> ObjectId {
         self.read_client.package_id()
     }
 
-    fn tf_components_package_id(&self) -> Option<ObjectID> {
+    fn tf_components_package_id(&self) -> Option<ObjectId> {
         Some(self.read_client.tf_components_package_id())
     }
 

--- a/audit-trail-rs/src/client/read_only.rs
+++ b/audit-trail-rs/src/client/read_only.rs
@@ -12,10 +12,11 @@ use std::ops::Deref;
 #[cfg(not(target_arch = "wasm32"))]
 use iota_interaction::IotaClient;
 use iota_interaction::IotaClientTrait;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::{ProgrammableTransaction, TransactionKind};
 #[cfg(target_arch = "wasm32")]
 use iota_interaction_ts::bindings::WasmIotaClient;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::network_name::NetworkName;
 use serde::de::DeserializeOwned;
@@ -33,9 +34,9 @@ use crate::package;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PackageOverrides {
     /// Override for the audit-trail package itself.
-    pub audit_trail: Option<ObjectID>,
+    pub audit_trail: Option<ObjectId>,
     /// Override for the `tf_components` package used by time locks and capabilities.
-    pub tf_component: Option<ObjectID>,
+    pub tf_component: Option<ObjectId>,
 }
 
 /// A read-only client for interacting with audit-trail objects on a specific network.
@@ -49,10 +50,10 @@ pub struct PackageOverrides {
 pub struct AuditTrailClientReadOnly {
     /// The underlying IOTA client adapter used for communication.
     iota_client: IotaClientAdapter,
-    /// The [`ObjectID`] of the deployed Audit Trail Package (smart contract).
-    audit_trail_pkg_id: ObjectID,
-    /// The [`ObjectID`] of the deployed TfComponents package used by Audit Trail.
-    pub(crate) tf_components_pkg_id: ObjectID,
+    /// The [`ObjectId`] of the deployed Audit Trail Package (smart contract).
+    audit_trail_pkg_id: ObjectId,
+    /// The [`ObjectId`] of the deployed TfComponents package used by Audit Trail.
+    pub(crate) tf_components_pkg_id: ObjectId,
     /// The name of the network this client is connected to (e.g., "mainnet", "testnet").
     network: NetworkName,
     /// Raw chain identifier returned by the IOTA node.
@@ -80,12 +81,12 @@ impl AuditTrailClientReadOnly {
     /// Returns the package ID used by this client.
     ///
     /// This is the deployed audit-trail Move package ID, not a trail object ID.
-    pub fn package_id(&self) -> ObjectID {
+    pub fn package_id(&self) -> ObjectId {
         self.audit_trail_pkg_id
     }
 
     /// Returns the TfComponents package ID used by this client.
-    pub fn tf_components_package_id(&self) -> ObjectID {
+    pub fn tf_components_package_id(&self) -> ObjectId {
         self.tf_components_pkg_id
     }
 
@@ -98,7 +99,7 @@ impl AuditTrailClientReadOnly {
     ///
     /// Creating the handle is cheap. Reads only happen when you call methods on the returned
     /// [`AuditTrailHandle`], such as [`AuditTrailHandle::get`].
-    pub fn trail<'a>(&'a self, trail_id: ObjectID) -> AuditTrailHandle<'a, Self> {
+    pub fn trail<'a>(&'a self, trail_id: ObjectId) -> AuditTrailHandle<'a, Self> {
         AuditTrailHandle::new(self, trail_id)
     }
 
@@ -164,11 +165,11 @@ impl AuditTrailClientReadOnly {
 #[cfg_attr(not(feature = "send-sync"), async_trait::async_trait(?Send))]
 #[cfg_attr(feature = "send-sync", async_trait::async_trait)]
 impl CoreClientReadOnly for AuditTrailClientReadOnly {
-    fn package_id(&self) -> ObjectID {
+    fn package_id(&self) -> ObjectId {
         self.audit_trail_pkg_id
     }
 
-    fn tf_components_package_id(&self) -> Option<ObjectID> {
+    fn tf_components_package_id(&self) -> Option<ObjectId> {
         Some(self.tf_components_pkg_id)
     }
 

--- a/audit-trail-rs/src/core/access/mod.rs
+++ b/audit-trail-rs/src/core/access/mod.rs
@@ -11,8 +11,8 @@
 //! records a role may operate on, but they do not replace the underlying permission checks enforced by the Move
 //! package.
 
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClient;
 use product_common::transaction::transaction_builder::TransactionBuilder;
 use secret_storage::Signer;
@@ -35,12 +35,12 @@ pub use transactions::{
 #[derive(Debug, Clone)]
 pub struct TrailAccess<'a, C> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) trail_id: ObjectId,
+    pub(crate) selected_capability_id: Option<ObjectId>,
 }
 
 impl<'a, C> TrailAccess<'a, C> {
-    pub(crate) fn new(client: &'a C, trail_id: ObjectID, selected_capability_id: Option<ObjectID>) -> Self {
+    pub(crate) fn new(client: &'a C, trail_id: ObjectId, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             client,
             trail_id,
@@ -49,7 +49,7 @@ impl<'a, C> TrailAccess<'a, C> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }
@@ -68,7 +68,7 @@ impl<'a, C> TrailAccess<'a, C> {
     /// when it is known so later cleanup keeps the same expiry semantics.
     pub fn revoke_capability<S>(
         &self,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
     ) -> TransactionBuilder<RevokeCapability>
     where
@@ -89,7 +89,7 @@ impl<'a, C> TrailAccess<'a, C> {
     ///
     /// This consumes the owned capability object itself. It uses the generic capability-destruction path and
     /// therefore must not be used for initial-admin capabilities.
-    pub fn destroy_capability<S>(&self, capability_id: ObjectID) -> TransactionBuilder<DestroyCapability>
+    pub fn destroy_capability<S>(&self, capability_id: ObjectId) -> TransactionBuilder<DestroyCapability>
     where
         C: AuditTrailFull + CoreClient<S>,
         S: Signer<IotaKeySignature> + OptionalSync,
@@ -109,7 +109,7 @@ impl<'a, C> TrailAccess<'a, C> {
     /// destroy path.
     pub fn destroy_initial_admin_capability<S>(
         &self,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
     ) -> TransactionBuilder<DestroyInitialAdminCapability>
     where
         C: AuditTrailFull + CoreClient<S>,
@@ -124,7 +124,7 @@ impl<'a, C> TrailAccess<'a, C> {
     /// because initial-admin capability IDs are protected separately.
     pub fn revoke_initial_admin_capability<S>(
         &self,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
     ) -> TransactionBuilder<RevokeInitialAdminCapability>
     where
@@ -166,17 +166,17 @@ impl<'a, C> TrailAccess<'a, C> {
 #[derive(Debug, Clone)]
 pub struct RoleHandle<'a, C> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
     pub(crate) name: String,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) selected_capability_id: Option<ObjectId>,
 }
 
 impl<'a, C> RoleHandle<'a, C> {
     pub(crate) fn new(
         client: &'a C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         name: String,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             client,
@@ -187,7 +187,7 @@ impl<'a, C> RoleHandle<'a, C> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }

--- a/audit-trail-rs/src/core/access/operations.rs
+++ b/audit-trail-rs/src/core/access/operations.rs
@@ -6,9 +6,10 @@
 //! These helpers encode Rust-side access inputs into the exact Move call shapes expected by the audit-trail
 //! package and apply the lightweight preflight checks that are cheaper to surface before submission.
 
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::{CallArg, ProgrammableTransaction};
 use iota_interaction::{OptionalSync, ident_str};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::internal::{trail as trail_reader, tx};
@@ -30,12 +31,12 @@ impl AccessOps {
     /// Rust side fails early with `Error::InvalidArgument` instead of relying on a later Move abort.
     pub(super) async fn create_role<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         name: String,
         permissions: PermissionSet,
         role_tags: Option<RoleTags>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -83,12 +84,12 @@ impl AccessOps {
     /// on-chain as part of the role definition.
     pub(super) async fn update_role<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         name: String,
         permissions: PermissionSet,
         role_tags: Option<RoleTags>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -137,10 +138,10 @@ impl AccessOps {
     /// access-control invariant enforced by the Move package.
     pub(super) async fn delete_role<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         name: String,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -168,11 +169,11 @@ impl AccessOps {
     /// `valid_until` semantics remains on-chain.
     pub(super) async fn issue_capability<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         role_name: String,
         options: CapabilityIssueOptions,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -203,11 +204,11 @@ impl AccessOps {
     /// losing the capability's original expiry boundary.
     pub(super) async fn revoke_capability<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -236,10 +237,10 @@ impl AccessOps {
     /// capability object rather than only its ID.
     pub(super) async fn destroy_capability<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
-        selected_capability_id: Option<ObjectID>,
+        capability_id: ObjectId,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -271,8 +272,8 @@ impl AccessOps {
     /// capability path.
     pub(super) async fn destroy_initial_admin_capability<C>(
         client: &C,
-        trail_id: ObjectID,
-        capability_id: ObjectID,
+        trail_id: ObjectId,
+        capability_id: ObjectId,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -294,11 +295,11 @@ impl AccessOps {
     /// separate Move entry point reserved for tracked initial-admin IDs.
     pub(super) async fn revoke_initial_admin_capability<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -327,9 +328,9 @@ impl AccessOps {
     /// objects and does not revoke any additional IDs.
     pub(super) async fn cleanup_revoked_capabilities<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -354,7 +355,7 @@ impl AccessOps {
 ///
 /// Roles may only reference tags that are defined on the trail itself so later record-tag checks
 /// stay consistent with the registry stored on-chain.
-async fn assert_role_tags_defined<C>(client: &C, trail_id: ObjectID, role_tags: &Option<RoleTags>) -> Result<(), Error>
+async fn assert_role_tags_defined<C>(client: &C, trail_id: ObjectId, role_tags: &Option<RoleTags>) -> Result<(), Error>
 where
     C: CoreClientReadOnly + OptionalSync,
 {

--- a/audit-trail-rs/src/core/access/transactions.rs
+++ b/audit-trail-rs/src/core/access/transactions.rs
@@ -9,8 +9,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEvents};
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -35,12 +36,12 @@ use crate::error::Error;
 /// On success a `RoleCreated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct CreateRole {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     name: String,
     permissions: PermissionSet,
     role_tags: Option<RoleTags>,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
@@ -49,12 +50,12 @@ impl CreateRole {
     ///
     /// `role_tags`, when present, are serialized as Move `record_tags::RoleTags` role data.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         name: String,
         permissions: PermissionSet,
         role_tags: Option<RoleTags>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -133,24 +134,24 @@ impl Transaction for CreateRole {
 /// On success a `RoleUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateRole {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     name: String,
     permissions: PermissionSet,
     role_tags: Option<RoleTags>,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateRole {
     /// Creates an `UpdateRole` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         name: String,
         permissions: PermissionSet,
         role_tags: Option<RoleTags>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -228,16 +229,16 @@ impl Transaction for UpdateRole {
 /// On success a `RoleDeleted` event is emitted.
 #[derive(Debug, Clone)]
 pub struct DeleteRole {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     name: String,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DeleteRole {
     /// Creates a `DeleteRole` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, name: String, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, name: String, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,
@@ -310,22 +311,22 @@ impl Transaction for DeleteRole {
 /// emitted on success.
 #[derive(Debug, Clone)]
 pub struct IssueCapability {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     role: String,
     options: CapabilityIssueOptions,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl IssueCapability {
     /// Creates an `IssueCapability` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         role: String,
         options: CapabilityIssueOptions,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -401,22 +402,22 @@ impl Transaction for IssueCapability {
 /// `CapabilityRevoked` event is emitted on success.
 #[derive(Debug, Clone)]
 pub struct RevokeCapability {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    capability_id: ObjectID,
+    capability_id: ObjectId,
     capability_valid_until: Option<u64>,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl RevokeCapability {
     /// Creates a `RevokeCapability` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -491,20 +492,20 @@ impl Transaction for RevokeCapability {
 /// success.
 #[derive(Debug, Clone)]
 pub struct DestroyCapability {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    capability_id: ObjectID,
-    selected_capability_id: Option<ObjectID>,
+    capability_id: ObjectId,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DestroyCapability {
     /// Creates a `DestroyCapability` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
-        selected_capability_id: Option<ObjectID>,
+        capability_id: ObjectId,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -583,14 +584,14 @@ impl Transaction for DestroyCapability {
 /// On success a `CapabilityDestroyed` event is emitted.
 #[derive(Debug, Clone)]
 pub struct DestroyInitialAdminCapability {
-    trail_id: ObjectID,
-    capability_id: ObjectID,
+    trail_id: ObjectId,
+    capability_id: ObjectId,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DestroyInitialAdminCapability {
     /// Creates a `DestroyInitialAdminCapability` transaction builder payload.
-    pub fn new(trail_id: ObjectID, capability_id: ObjectID) -> Self {
+    pub fn new(trail_id: ObjectId, capability_id: ObjectId) -> Self {
         Self {
             trail_id,
             capability_id,
@@ -660,22 +661,22 @@ impl Transaction for DestroyInitialAdminCapability {
 /// On success a `CapabilityRevoked` event is emitted.
 #[derive(Debug, Clone)]
 pub struct RevokeInitialAdminCapability {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    capability_id: ObjectID,
+    capability_id: ObjectId,
     capability_valid_until: Option<u64>,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl RevokeInitialAdminCapability {
     /// Creates a `RevokeInitialAdminCapability` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        capability_id: ObjectID,
+        capability_id: ObjectId,
         capability_valid_until: Option<u64>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -755,15 +756,15 @@ impl Transaction for RevokeInitialAdminCapability {
 /// triggered the cleanup, and the millisecond timestamp.
 #[derive(Debug, Clone)]
 pub struct CleanupRevokedCapabilities {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl CleanupRevokedCapabilities {
     /// Creates a `CleanupRevokedCapabilities` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,

--- a/audit-trail-rs/src/core/create/operations.rs
+++ b/audit-trail-rs/src/core/create/operations.rs
@@ -6,9 +6,10 @@
 use std::collections::HashSet;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_interaction::types::transaction::{Argument, ProgrammableTransaction};
+use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::{Argument, ObjectId};
 
 use crate::core::internal::tx;
 use crate::core::types::{Data, ImmutableMetadata, InitialRecord, LockingConfig};
@@ -22,9 +23,9 @@ pub(super) struct CreateOps;
 /// This keeps the public builder layer separate from the low-level PTB encoding logic.
 pub(super) struct CreateTrailArgs {
     /// Audit-trail package used for generic type tags and Move calls.
-    pub audit_trail_package_id: ObjectID,
+    pub audit_trail_package_id: ObjectId,
     /// TfComponents package used by locking and capability-related values.
-    pub tf_components_package_id: ObjectID,
+    pub tf_components_package_id: ObjectId,
     /// Address that should receive the initial admin capability.
     pub admin: IotaAddress,
     /// Optional first record inserted into the newly created trail.

--- a/audit-trail-rs/src/core/create/transactions.rs
+++ b/audit-trail-rs/src/core/create/transactions.rs
@@ -4,8 +4,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEvents};
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -20,7 +21,7 @@ use crate::error::Error;
 #[derive(Debug, Clone)]
 pub struct TrailCreated {
     /// Newly created trail object ID.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that created the trail.
     pub creator: IotaAddress,
     /// Millisecond timestamp emitted by the creation event.

--- a/audit-trail-rs/src/core/internal/capability.rs
+++ b/audit-trail-rs/src/core/internal/capability.rs
@@ -245,8 +245,9 @@ pub(crate) fn now_ms() -> u64 {
 mod tests {
     use std::collections::HashSet;
 
-    use iota_interaction::types::base_types::{IotaAddress, ObjectId, dbg_object_id};
+    use iota_interaction::types::base_types::{IotaAddress, dbg_object_id};
     use iota_interaction::types::id::UID;
+    use iota_sdk_types::ObjectId;
 
     use super::capability_matches;
     use crate::core::types::Capability;

--- a/audit-trail-rs/src/core/internal/capability.rs
+++ b/audit-trail-rs/src/core/internal/capability.rs
@@ -8,10 +8,11 @@ use iota_interaction::rpc_types::{
     IotaObjectDataFilter, IotaObjectDataOptions, IotaObjectResponseQuery, IotaParsedData,
 };
 use iota_interaction::types::MoveTypeTagTrait;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, ObjectRef, StructTag};
+use iota_interaction::types::base_types::{IotaAddress, ObjectRef};
 use iota_interaction::types::dynamic_field::DynamicFieldName;
 use iota_interaction::types::id::ID;
 use iota_interaction::{IotaClientTrait, OptionalSync};
+use iota_sdk_types::{ObjectId, StructTag};
 use product_common::core_client::CoreClientReadOnly;
 
 use super::{linked_table, tx};
@@ -25,7 +26,7 @@ use crate::error::Error;
 pub(crate) async fn find_capable_cap<C>(
     client: &C,
     owner: IotaAddress,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     trail: &OnChainAuditTrail,
     permission: Permission,
 ) -> Result<ObjectRef, Error>
@@ -120,7 +121,7 @@ where
 ///
 /// The traversal validates that the linked-table shape is acyclic and that the number of visited
 /// entries matches the size recorded on-chain.
-async fn revoked_capability_ids<C>(client: &C, trail: &OnChainAuditTrail) -> Result<HashSet<ObjectID>, Error>
+async fn revoked_capability_ids<C>(client: &C, trail: &OnChainAuditTrail) -> Result<HashSet<ObjectId>, Error>
 where
     C: CoreClientReadOnly + OptionalSync,
 {
@@ -137,7 +138,7 @@ where
             )));
         }
 
-        let node = linked_table::fetch_node::<_, ObjectID, u64>(
+        let node = linked_table::fetch_node::<_, ObjectId, u64>(
             client,
             table.id,
             DynamicFieldName {
@@ -167,7 +168,7 @@ fn capability_matches<P>(
     cap: &Capability,
     owner: IotaAddress,
     now_ms: u64,
-    revoked_capability_ids: &HashSet<ObjectID>,
+    revoked_capability_ids: &HashSet<ObjectId>,
     predicate: &P,
 ) -> bool
 where
@@ -188,7 +189,7 @@ where
 pub(crate) async fn find_capable_cap_for_tag<C>(
     client: &C,
     owner: IotaAddress,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     trail: &OnChainAuditTrail,
     tag: &str,
 ) -> Result<ObjectRef, Error>
@@ -244,7 +245,7 @@ pub(crate) fn now_ms() -> u64 {
 mod tests {
     use std::collections::HashSet;
 
-    use iota_interaction::types::base_types::{IotaAddress, ObjectID, dbg_object_id};
+    use iota_interaction::types::base_types::{IotaAddress, ObjectId, dbg_object_id};
     use iota_interaction::types::id::UID;
 
     use super::capability_matches;
@@ -359,8 +360,8 @@ mod tests {
     }
 
     fn make_capability(
-        id: ObjectID,
-        trail_id: ObjectID,
+        id: ObjectId,
+        trail_id: ObjectId,
         role: &str,
         issued_to: Option<IotaAddress>,
         valid_from: Option<u64>,

--- a/audit-trail-rs/src/core/internal/linked_table.rs
+++ b/audit-trail-rs/src/core/internal/linked_table.rs
@@ -4,10 +4,10 @@
 //! Helpers for reading Move `LinkedTable` nodes through dynamic fields.
 
 use iota_interaction::rpc_types::{IotaData as _, IotaObjectDataOptions};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::collection_types::LinkedTableNode;
 use iota_interaction::types::dynamic_field::{DynamicFieldName, Field};
 use iota_interaction::{IotaClientTrait, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use serde::de::DeserializeOwned;
 
@@ -19,7 +19,7 @@ use crate::error::Error;
 /// linked-table key and value types.
 pub(crate) async fn fetch_node<C, K, V>(
     client: &C,
-    table_id: ObjectID,
+    table_id: ObjectId,
     name: DynamicFieldName,
 ) -> Result<LinkedTableNode<K, V>, Error>
 where

--- a/audit-trail-rs/src/core/internal/trail.rs
+++ b/audit-trail-rs/src/core/internal/trail.rs
@@ -4,15 +4,15 @@
 //! Helpers for fetching and decoding the shared on-chain audit-trail object.
 
 use iota_interaction::rpc_types::{IotaData as _, IotaObjectDataOptions};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaClientTrait, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::types::OnChainAuditTrail;
 use crate::error::Error;
 
 /// Loads the shared audit-trail object and decodes it into [`OnChainAuditTrail`].
-pub(crate) async fn get_audit_trail<C>(trail_id: ObjectID, client: &C) -> Result<OnChainAuditTrail, Error>
+pub(crate) async fn get_audit_trail<C>(trail_id: ObjectId, client: &C) -> Result<OnChainAuditTrail, Error>
 where
     C: CoreClientReadOnly + OptionalSync,
 {

--- a/audit-trail-rs/src/core/internal/tx.rs
+++ b/audit-trail-rs/src/core/internal/tx.rs
@@ -6,14 +6,14 @@
 use std::str::FromStr;
 
 use iota_interaction::rpc_types::IotaObjectDataOptions;
-use iota_interaction::types::base_types::{Identifier, IotaAddress, ObjectID, ObjectRef, TypeTag};
-use iota_interaction::types::object::Owner;
+use iota_interaction::types::base_types::{IotaAddress, ObjectRef};
 use iota_interaction::types::programmable_transaction_builder::{
     ProgrammableTransactionBuilder as Ptb, ProgrammableTransactionBuilder,
 };
-use iota_interaction::types::transaction::{Argument, CallArg, ProgrammableTransaction, SharedObjectRef};
+use iota_interaction::types::transaction::{CallArg, ProgrammableTransaction, SharedObjectRef};
 use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION, MOVE_STDLIB_PACKAGE_ID};
 use iota_interaction::{IotaClientTrait, OptionalSync, ident_str};
+use iota_sdk_types::{Argument, Identifier, ObjectId, Owner, TypeTag};
 use product_common::core_client::CoreClientReadOnly;
 use serde::Serialize;
 
@@ -75,10 +75,10 @@ pub(crate) fn option_to_move(
 /// capability for `owner`.
 pub(crate) async fn build_trail_transaction<C, F>(
     client: &C,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     permission: Permission,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     method: impl AsRef<str>,
     additional_args: F,
 ) -> Result<ProgrammableTransaction, Error>
@@ -99,7 +99,7 @@ where
 /// reference.
 pub(crate) async fn build_trail_transaction_with_cap_ref<C, F>(
     client: &C,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     cap_ref: ObjectRef,
     method: impl AsRef<str>,
     additional_args: F,
@@ -140,7 +140,7 @@ where
 /// Builds a read-only trail transaction that borrows the shared trail object immutably.
 pub(crate) async fn build_read_only_transaction<C, F>(
     client: &C,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     method: impl AsRef<str>,
     additional_args: F,
 ) -> Result<ProgrammableTransaction, Error>
@@ -178,7 +178,7 @@ where
 ///
 /// Audit-trail Move entry points are generic over the record payload type, so transaction builders
 /// need this type tag to invoke the correct specialization.
-pub(crate) async fn get_type_tag<C>(client: &C, object_id: &ObjectID) -> Result<TypeTag, Error>
+pub(crate) async fn get_type_tag<C>(client: &C, object_id: &ObjectId) -> Result<TypeTag, Error>
 where
     C: CoreClientReadOnly + OptionalSync,
 {
@@ -218,7 +218,7 @@ fn parse_type(full_type: &str) -> Result<String, Error> {
 /// Fetches the current object reference for `object_id`.
 pub(crate) async fn get_object_ref_by_id(
     client: &impl CoreClientReadOnly,
-    object_id: &ObjectID,
+    object_id: &ObjectId,
 ) -> Result<ObjectRef, Error> {
     let res = client
         .client_adapter()
@@ -240,7 +240,7 @@ pub(crate) async fn get_object_ref_by_id(
 /// the planned call.
 pub(crate) async fn get_shared_object_arg(
     client: &impl CoreClientReadOnly,
-    object_id: &ObjectID,
+    object_id: &ObjectId,
     mutable: bool,
 ) -> Result<CallArg, Error> {
     let res = client

--- a/audit-trail-rs/src/core/locking/mod.rs
+++ b/audit-trail-rs/src/core/locking/mod.rs
@@ -3,8 +3,8 @@
 
 //! Locking configuration APIs for Audit Trails.
 
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClient;
 use product_common::transaction::transaction_builder::TransactionBuilder;
 use secret_storage::Signer;
@@ -27,12 +27,12 @@ use self::operations::LockingOps;
 #[derive(Debug, Clone)]
 pub struct TrailLocking<'a, C> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) trail_id: ObjectId,
+    pub(crate) selected_capability_id: Option<ObjectId>,
 }
 
 impl<'a, C> TrailLocking<'a, C> {
-    pub(crate) fn new(client: &'a C, trail_id: ObjectID, selected_capability_id: Option<ObjectID>) -> Self {
+    pub(crate) fn new(client: &'a C, trail_id: ObjectId, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             client,
             trail_id,
@@ -41,7 +41,7 @@ impl<'a, C> TrailLocking<'a, C> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }

--- a/audit-trail-rs/src/core/locking/operations.rs
+++ b/audit-trail-rs/src/core/locking/operations.rs
@@ -7,8 +7,9 @@
 //! corresponding locking-update permissions.
 
 use iota_interaction::OptionalSync;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::internal::tx;
@@ -22,10 +23,10 @@ impl LockingOps {
     /// Builds the `update_locking_config` call.
     pub(super) async fn update_locking_config<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         new_config: LockingConfig,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -54,10 +55,10 @@ impl LockingOps {
     /// Builds the `update_delete_record_window` call.
     pub(super) async fn update_delete_record_window<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         new_delete_record_window: LockingWindow,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -82,10 +83,10 @@ impl LockingOps {
     /// Builds the `update_delete_trail_lock` call.
     pub(super) async fn update_delete_trail_lock<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         new_delete_trail_lock: TimeLock,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -113,10 +114,10 @@ impl LockingOps {
     /// Builds the `update_write_lock` call.
     pub(super) async fn update_write_lock<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         new_write_lock: TimeLock,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -144,7 +145,7 @@ impl LockingOps {
     /// Builds the read-only `is_record_locked` call.
     pub(super) async fn is_record_locked<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         sequence_number: u64,
     ) -> Result<ProgrammableTransaction, Error>
     where

--- a/audit-trail-rs/src/core/locking/transactions.rs
+++ b/audit-trail-rs/src/core/locking/transactions.rs
@@ -6,8 +6,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -25,20 +26,20 @@ use crate::error::Error;
 /// On success a `LockingConfigUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateLockingConfig {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     config: LockingConfig,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateLockingConfig {
     /// Creates an `UpdateLockingConfig` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         config: LockingConfig,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -94,20 +95,20 @@ impl Transaction for UpdateLockingConfig {
 /// On success a `LockingConfigUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateDeleteRecordWindow {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     window: LockingWindow,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateDeleteRecordWindow {
     /// Creates an `UpdateDeleteRecordWindow` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         window: LockingWindow,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -163,20 +164,20 @@ impl Transaction for UpdateDeleteRecordWindow {
 /// On success a `LockingConfigUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateDeleteTrailLock {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     lock: TimeLock,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateDeleteTrailLock {
     /// Creates an `UpdateDeleteTrailLock` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         lock: TimeLock,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -231,20 +232,20 @@ impl Transaction for UpdateDeleteTrailLock {
 /// On success a `LockingConfigUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateWriteLock {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     lock: TimeLock,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateWriteLock {
     /// Creates an `UpdateWriteLock` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         lock: TimeLock,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,

--- a/audit-trail-rs/src/core/records/mod.rs
+++ b/audit-trail-rs/src/core/records/mod.rs
@@ -7,10 +7,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use iota_interaction::move_core_types::annotated_value::MoveValue;
 use iota_interaction::rpc_types::IotaMoveValue;
-use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::collection_types::LinkedTable;
 use iota_interaction::types::dynamic_field::DynamicFieldName;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::{ObjectId, TypeTag};
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::transaction::transaction_builder::TransactionBuilder;
 use secret_storage::Signer;
@@ -36,13 +36,13 @@ const MAX_LIST_PAGE_LIMIT: usize = 1_000;
 #[derive(Debug, Clone)]
 pub struct TrailRecords<'a, C, D = Data> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) trail_id: ObjectId,
+    pub(crate) selected_capability_id: Option<ObjectId>,
     pub(crate) _phantom: std::marker::PhantomData<D>,
 }
 
 impl<'a, C, D> TrailRecords<'a, C, D> {
-    pub(crate) fn new(client: &'a C, trail_id: ObjectID, selected_capability_id: Option<ObjectID>) -> Self {
+    pub(crate) fn new(client: &'a C, trail_id: ObjectId, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             client,
             trail_id,
@@ -52,7 +52,7 @@ impl<'a, C, D> TrailRecords<'a, C, D> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }

--- a/audit-trail-rs/src/core/records/operations.rs
+++ b/audit-trail-rs/src/core/records/operations.rs
@@ -7,8 +7,9 @@
 //! arguments expected by the trail package.
 
 use iota_interaction::OptionalSync;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::internal::capability::find_capable_cap_for_tag;
@@ -26,12 +27,12 @@ impl RecordsOps {
     /// both `AddRecord` and the requested tag.
     pub(super) async fn add_record<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         data: Data,
         record_metadata: Option<String>,
         record_tag: Option<String>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -87,10 +88,10 @@ impl RecordsOps {
     /// Authorization and locking remain enforced by the Move entry point.
     pub(super) async fn delete_record<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         sequence_number: u64,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -121,10 +122,10 @@ impl RecordsOps {
     /// than `limit` records may be visited before `limit` deletions accumulate.
     pub(super) async fn delete_records_batch<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         limit: u64,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -148,7 +149,7 @@ impl RecordsOps {
     /// Builds the read-only `get_record` call.
     pub(super) async fn get_record<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         sequence_number: u64,
     ) -> Result<ProgrammableTransaction, Error>
     where
@@ -162,7 +163,7 @@ impl RecordsOps {
     }
 
     /// Builds the read-only `record_count` call.
-    pub(super) async fn record_count<C>(client: &C, trail_id: ObjectID) -> Result<ProgrammableTransaction, Error>
+    pub(super) async fn record_count<C>(client: &C, trail_id: ObjectId) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {

--- a/audit-trail-rs/src/core/records/transactions.rs
+++ b/audit-trail-rs/src/core/records/transactions.rs
@@ -9,8 +9,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEvents};
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -32,7 +33,7 @@ use crate::error::Error;
 #[derive(Debug, Clone)]
 pub struct AddRecord {
     /// Trail object ID that will receive the record.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address authorizing the write.
     pub owner: IotaAddress,
     /// Record payload to append.
@@ -42,19 +43,19 @@ pub struct AddRecord {
     /// Optional trail-owned tag to attach to the record.
     pub tag: Option<String>,
     /// Explicit capability to use instead of auto-selecting one from the owner's wallet.
-    pub selected_capability_id: Option<ObjectID>,
+    pub selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl AddRecord {
     /// Creates an `AddRecord` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         data: Data,
         metadata: Option<String>,
         tag: Option<String>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -136,23 +137,23 @@ impl Transaction for AddRecord {
 #[derive(Debug, Clone)]
 pub struct DeleteRecord {
     /// Trail object ID containing the record.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address authorizing the deletion.
     pub owner: IotaAddress,
     /// Sequence number of the record to delete.
     pub sequence_number: u64,
     /// Explicit capability to use instead of auto-selecting one from the owner's wallet.
-    pub selected_capability_id: Option<ObjectID>,
+    pub selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DeleteRecord {
     /// Creates a `DeleteRecord` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         sequence_number: u64,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -239,19 +240,19 @@ impl Transaction for DeleteRecord {
 #[derive(Debug, Clone)]
 pub struct DeleteRecordsBatch {
     /// Trail object ID containing the records.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address authorizing the deletion.
     pub owner: IotaAddress,
     /// Maximum number of records to delete in this batch.
     pub limit: u64,
     /// Explicit capability to use instead of auto-selecting one from the owner's wallet.
-    pub selected_capability_id: Option<ObjectID>,
+    pub selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DeleteRecordsBatch {
     /// Creates a `DeleteRecordsBatch` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, limit: u64, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, limit: u64, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,

--- a/audit-trail-rs/src/core/tags/mod.rs
+++ b/audit-trail-rs/src/core/tags/mod.rs
@@ -3,8 +3,8 @@
 
 //! Record-tag registry APIs for Audit Trails.
 
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClient;
 use product_common::transaction::transaction_builder::TransactionBuilder;
 use secret_storage::Signer;
@@ -22,12 +22,12 @@ pub use transactions::{AddRecordTag, RemoveRecordTag};
 #[derive(Debug, Clone)]
 pub struct TrailTags<'a, C> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) trail_id: ObjectId,
+    pub(crate) selected_capability_id: Option<ObjectId>,
 }
 
 impl<'a, C> TrailTags<'a, C> {
-    pub(crate) fn new(client: &'a C, trail_id: ObjectID, selected_capability_id: Option<ObjectID>) -> Self {
+    pub(crate) fn new(client: &'a C, trail_id: ObjectId, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             client,
             trail_id,
@@ -36,7 +36,7 @@ impl<'a, C> TrailTags<'a, C> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }

--- a/audit-trail-rs/src/core/tags/operations.rs
+++ b/audit-trail-rs/src/core/tags/operations.rs
@@ -7,8 +7,9 @@
 //! permissions.
 
 use iota_interaction::OptionalSync;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::internal::tx;
@@ -22,10 +23,10 @@ impl TagsOps {
     /// Builds the `add_record_tag` call.
     pub(super) async fn add_record_tag<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         tag: String,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -49,10 +50,10 @@ impl TagsOps {
     /// Builds the `remove_record_tag` call.
     pub(super) async fn remove_record_tag<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         tag: String,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,

--- a/audit-trail-rs/src/core/tags/transactions.rs
+++ b/audit-trail-rs/src/core/tags/transactions.rs
@@ -6,8 +6,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -23,16 +24,16 @@ use crate::error::Error;
 /// On success a `RecordTagAdded` event is emitted.
 #[derive(Debug, Clone)]
 pub struct AddRecordTag {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     tag: String,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl AddRecordTag {
     /// Creates an `AddRecordTag` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, tag: String, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, tag: String, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,
@@ -87,16 +88,16 @@ impl Transaction for AddRecordTag {
 /// On success a `RecordTagRemoved` event is emitted.
 #[derive(Debug, Clone)]
 pub struct RemoveRecordTag {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     tag: String,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl RemoveRecordTag {
     /// Creates a `RemoveRecordTag` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, tag: String, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, tag: String, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,

--- a/audit-trail-rs/src/core/trail.rs
+++ b/audit-trail-rs/src/core/trail.rs
@@ -3,9 +3,9 @@
 
 //! High-level trail handles and trail-scoped transactions.
 
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::transaction::ProgrammableTransaction;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::transaction::transaction_builder::TransactionBuilder;
 use secret_storage::Signer;
@@ -45,12 +45,12 @@ pub trait AuditTrailFull: AuditTrailReadOnly {}
 #[derive(Debug, Clone)]
 pub struct AuditTrailHandle<'a, C> {
     pub(crate) client: &'a C,
-    pub(crate) trail_id: ObjectID,
-    pub(crate) selected_capability_id: Option<ObjectID>,
+    pub(crate) trail_id: ObjectId,
+    pub(crate) selected_capability_id: Option<ObjectId>,
 }
 
 impl<'a, C> AuditTrailHandle<'a, C> {
-    pub(crate) fn new(client: &'a C, trail_id: ObjectID) -> Self {
+    pub(crate) fn new(client: &'a C, trail_id: ObjectId) -> Self {
         Self {
             client,
             trail_id,
@@ -59,7 +59,7 @@ impl<'a, C> AuditTrailHandle<'a, C> {
     }
 
     /// Uses the provided capability as the auth capability for subsequent write operations.
-    pub fn using_capability(mut self, capability_id: ObjectID) -> Self {
+    pub fn using_capability(mut self, capability_id: ObjectId) -> Self {
         self.selected_capability_id = Some(capability_id);
         self
     }

--- a/audit-trail-rs/src/core/trail/operations.rs
+++ b/audit-trail-rs/src/core/trail/operations.rs
@@ -7,8 +7,9 @@
 //! and deletion calls.
 
 use iota_interaction::OptionalSync;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 
 use crate::core::internal::tx;
@@ -22,9 +23,9 @@ impl TrailOps {
     /// Builds the `migrate` call.
     pub(super) async fn migrate<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -47,10 +48,10 @@ impl TrailOps {
     /// Builds the `update_metadata` call.
     pub(super) async fn update_metadata<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         metadata: Option<String>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
@@ -74,9 +75,9 @@ impl TrailOps {
     /// Builds the `delete_audit_trail` call.
     pub(super) async fn delete_audit_trail<C>(
         client: &C,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,

--- a/audit-trail-rs/src/core/trail/transactions.rs
+++ b/audit-trail-rs/src/core/trail/transactions.rs
@@ -6,8 +6,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::{IotaTransactionBlockEffects, IotaTransactionBlockEvents};
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -25,15 +26,15 @@ use crate::error::Error;
 /// On success an `AuditTrailMigrated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct Migrate {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl Migrate {
     /// Creates a `Migrate` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,
@@ -79,20 +80,20 @@ impl Transaction for Migrate {
 /// On success a `MetadataUpdated` event is emitted.
 #[derive(Debug, Clone)]
 pub struct UpdateMetadata {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
     metadata: Option<String>,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateMetadata {
     /// Creates an `UpdateMetadata` transaction builder payload.
     pub fn new(
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         owner: IotaAddress,
         metadata: Option<String>,
-        selected_capability_id: Option<ObjectID>,
+        selected_capability_id: Option<ObjectId>,
     ) -> Self {
         Self {
             trail_id,
@@ -148,15 +149,15 @@ impl Transaction for UpdateMetadata {
 /// On success an `AuditTrailDeleted` event is emitted.
 #[derive(Debug, Clone)]
 pub struct DeleteAuditTrail {
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     owner: IotaAddress,
-    selected_capability_id: Option<ObjectID>,
+    selected_capability_id: Option<ObjectId>,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DeleteAuditTrail {
     /// Creates a `DeleteAuditTrail` transaction builder payload.
-    pub fn new(trail_id: ObjectID, owner: IotaAddress, selected_capability_id: Option<ObjectID>) -> Self {
+    pub fn new(trail_id: ObjectId, owner: IotaAddress, selected_capability_id: Option<ObjectId>) -> Self {
         Self {
             trail_id,
             owner,

--- a/audit-trail-rs/src/core/types/audit_trail.rs
+++ b/audit-trail-rs/src/core/types/audit_trail.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, TypeTag};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::collection_types::LinkedTable;
 use iota_interaction::types::id::UID;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::Argument;
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use serde::{Deserialize, Serialize};
 
 use super::locking::LockingConfig;
@@ -105,7 +105,7 @@ impl ImmutableMetadata {
         Self { name, description }
     }
 
-    pub(in crate::core) fn tag(package_id: ObjectID) -> TypeTag {
+    pub(in crate::core) fn tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(&format!("{package_id}::main::ImmutableMetadata"))
             .expect("invalid TypeTag for ImmutableMetadata")
     }
@@ -113,7 +113,7 @@ impl ImmutableMetadata {
     /// Creates a new `Argument` from the `ImmutableMetadata`.
     ///
     /// To be used when creating a new `ImmutableMetadata` object on the ledger.
-    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         let name = tx::ptb_pure(ptb, "name", &self.name)?;
         let description = tx::ptb_pure(ptb, "description", &self.description)?;
 

--- a/audit-trail-rs/src/core/types/event.rs
+++ b/audit-trail-rs/src/core/types/event.rs
@@ -3,8 +3,9 @@
 
 use std::collections::HashSet;
 
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::collection_types::VecSet;
+use iota_sdk_types::ObjectId;
 use serde::{Deserialize, Serialize};
 use serde_aux::field_attributes::{deserialize_number_from_string, deserialize_option_number_from_string};
 
@@ -22,7 +23,7 @@ pub struct Event<D> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuditTrailCreated {
     /// Newly created trail object ID.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that created the trail.
     pub creator: IotaAddress,
     /// Millisecond event timestamp.
@@ -34,7 +35,7 @@ pub struct AuditTrailCreated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuditTrailDeleted {
     /// Deleted trail object ID.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Millisecond event timestamp.
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub timestamp: u64,
@@ -44,7 +45,7 @@ pub struct AuditTrailDeleted {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuditTrailMigrated {
     /// Migrated trail object ID.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that migrated the trail.
     pub migrated_by: IotaAddress,
     /// Millisecond event timestamp.
@@ -56,7 +57,7 @@ pub struct AuditTrailMigrated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataUpdated {
     /// Trail object ID whose metadata changed.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that updated the metadata.
     pub updated_by: IotaAddress,
     /// Millisecond event timestamp.
@@ -68,7 +69,7 @@ pub struct MetadataUpdated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockingConfigUpdated {
     /// Trail object ID whose locking configuration changed.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that updated the locking configuration.
     pub updated_by: IotaAddress,
     /// Millisecond event timestamp.
@@ -80,7 +81,7 @@ pub struct LockingConfigUpdated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordAdded {
     /// Trail object ID receiving the new record.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Sequence number assigned to the new record.
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub sequence_number: u64,
@@ -95,7 +96,7 @@ pub struct RecordAdded {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordDeleted {
     /// Trail object ID from which the record was deleted.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Sequence number of the deleted record.
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub sequence_number: u64,
@@ -110,7 +111,7 @@ pub struct RecordDeleted {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordTagAdded {
     /// Trail object ID whose registry changed.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that added the tag.
     pub added_by: IotaAddress,
     /// Millisecond event timestamp.
@@ -122,7 +123,7 @@ pub struct RecordTagAdded {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordTagRemoved {
     /// Trail object ID whose registry changed.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Address that removed the tag.
     pub removed_by: IotaAddress,
     /// Millisecond event timestamp.
@@ -134,9 +135,9 @@ pub struct RecordTagRemoved {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilityIssued {
     /// Trail object ID protected by the capability.
-    pub target_key: ObjectID,
+    pub target_key: ObjectId,
     /// Newly created capability object ID.
-    pub capability_id: ObjectID,
+    pub capability_id: ObjectId,
     /// Role granted by the capability.
     pub role: String,
     /// Address receiving the capability, if one is assigned.
@@ -153,9 +154,9 @@ pub struct CapabilityIssued {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilityDestroyed {
     /// Trail object ID protected by the capability.
-    pub target_key: ObjectID,
+    pub target_key: ObjectId,
     /// Destroyed capability object ID.
-    pub capability_id: ObjectID,
+    pub capability_id: ObjectId,
     /// Role granted by the capability.
     pub role: String,
     /// Address that held the capability, if any.
@@ -172,9 +173,9 @@ pub struct CapabilityDestroyed {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilityRevoked {
     /// Trail object ID protected by the capability.
-    pub target_key: ObjectID,
+    pub target_key: ObjectId,
     /// Revoked capability object ID.
-    pub capability_id: ObjectID,
+    pub capability_id: ObjectId,
     /// Millisecond timestamp retained for denylist cleanup.
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub valid_until: u64,
@@ -184,7 +185,7 @@ pub struct CapabilityRevoked {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RevokedCapabilitiesCleanedUp {
     /// Trail object ID whose denylist was pruned.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Number of expired entries removed by this cleanup call.
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub cleaned_count: u64,
@@ -199,7 +200,7 @@ pub struct RevokedCapabilitiesCleanedUp {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RoleCreated {
     /// Trail object ID that owns the role.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Role name.
     pub role: String,
     /// Permissions granted by the new role.
@@ -216,7 +217,7 @@ pub struct RoleCreated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RoleUpdated {
     /// Trail object ID that owns the role.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Role name.
     pub role: String,
     /// Updated permissions for the role.
@@ -233,7 +234,7 @@ pub struct RoleUpdated {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RoleDeleted {
     /// Trail object ID that owned the role.
-    pub trail_id: ObjectID,
+    pub trail_id: ObjectId,
     /// Role name.
     pub role: String,
     /// Address that deleted the role.
@@ -244,7 +245,7 @@ pub struct RoleDeleted {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct RawRoleCreated {
-    target_key: ObjectID,
+    target_key: ObjectId,
     role: String,
     permissions: VecSet<Permission>,
     data: Option<RawRoleTags>,
@@ -254,7 +255,7 @@ pub(crate) struct RawRoleCreated {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct RawRoleUpdated {
-    target_key: ObjectID,
+    target_key: ObjectId,
     role: String,
     new_permissions: VecSet<Permission>,
     new_data: Option<RawRoleTags>,
@@ -264,7 +265,7 @@ pub(crate) struct RawRoleUpdated {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct RawRoleDeleted {
-    target_key: ObjectID,
+    target_key: ObjectId,
     role: String,
     deleted_by: IotaAddress,
     timestamp: u64,
@@ -330,13 +331,13 @@ impl From<RawRoleDeleted> for RoleDeleted {
 
 #[cfg(test)]
 mod tests {
-    use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+    use iota_sdk_types::ObjectId;
     use serde_json::json;
 
     use super::*;
     #[test]
     fn metadata_updated_event_deserializes_string_encoded_timestamp() {
-        let trail_id = ObjectID::random();
+        let trail_id = ObjectId::random();
         let updated_by = IotaAddress::random();
 
         let event: Event<MetadataUpdated> = serde_json::from_value(json!({
@@ -353,7 +354,7 @@ mod tests {
 
     #[test]
     fn locking_config_updated_event_deserializes_string_encoded_timestamp() {
-        let trail_id = ObjectID::random();
+        let trail_id = ObjectId::random();
         let updated_by = IotaAddress::random();
 
         let event: Event<LockingConfigUpdated> = serde_json::from_value(json!({
@@ -370,7 +371,7 @@ mod tests {
 
     #[test]
     fn record_tag_events_deserialize_string_encoded_timestamps() {
-        let trail_id = ObjectID::random();
+        let trail_id = ObjectId::random();
         let actor = IotaAddress::random();
 
         let added: Event<RecordTagAdded> = serde_json::from_value(json!({
@@ -396,7 +397,7 @@ mod tests {
 
     #[test]
     fn audit_trail_migrated_event_deserializes_string_encoded_timestamp() {
-        let trail_id = ObjectID::random();
+        let trail_id = ObjectId::random();
         let migrated_by = IotaAddress::random();
 
         let event: Event<AuditTrailMigrated> = serde_json::from_value(json!({

--- a/audit-trail-rs/src/core/types/locking.rs
+++ b/audit-trail-rs/src/core/types/locking.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::Argument;
+use iota_sdk_types::{Argument, ObjectId};
 use serde::{Deserialize, Serialize};
 
 use crate::core::internal::tx;
@@ -57,8 +56,8 @@ impl LockingConfig {
     pub(in crate::core) fn to_ptb(
         &self,
         ptb: &mut Ptb,
-        package_id: ObjectID,
-        tf_components_package_id: ObjectID,
+        package_id: ObjectId,
+        tf_components_package_id: ObjectId,
     ) -> Result<Argument, Error> {
         let delete_record_window = self.delete_record_window.to_ptb(ptb, package_id)?;
         let delete_trail_lock = self.delete_trail_lock.to_ptb(ptb, tf_components_package_id)?;
@@ -111,7 +110,7 @@ impl TimeLock {
         Ok(())
     }
 
-    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         match self {
             Self::None => Ok(ptb.programmable_move_call(
                 package_id,
@@ -213,7 +212,7 @@ impl LockingWindow {
     /// Creates a new `Argument` from the `LockingWindow`.
     ///
     /// To be used when creating or updating locking config on the ledger.
-    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         self.validate()?;
         match self {
             Self::None => Ok(ptb.programmable_move_call(

--- a/audit-trail-rs/src/core/types/permission.rs
+++ b/audit-trail-rs/src/core/types/permission.rs
@@ -5,9 +5,8 @@ use std::collections::HashSet;
 use std::str::FromStr;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::{Identifier, ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::{Argument, Command, MakeMoveVector};
+use iota_sdk_types::{Argument, Command, Identifier, MakeMoveVector, ObjectId, TypeTag};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -87,11 +86,11 @@ impl Permission {
         }
     }
 
-    pub(crate) fn tag(package_id: ObjectID) -> TypeTag {
+    pub(crate) fn tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(&format!("{package_id}::permission::Permission")).expect("invalid TypeTag for Permission")
     }
 
-    pub(in crate::core) fn to_ptb(self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         let function = Identifier::from_str(self.function_name())
             .map_err(|e| Error::InvalidArgument(format!("Failed to create identifier for function: {e}")))?;
 
@@ -113,7 +112,7 @@ pub struct PermissionSet {
 }
 
 impl PermissionSet {
-    pub(crate) fn to_move_vec(&self, package_id: ObjectID, ptb: &mut Ptb) -> Result<Argument, Error> {
+    pub(crate) fn to_move_vec(&self, package_id: ObjectId, ptb: &mut Ptb) -> Result<Argument, Error> {
         let permission_type = Permission::tag(package_id);
         let permission_args: Vec<_> = self
             .permissions

--- a/audit-trail-rs/src/core/types/record.rs
+++ b/audit-trail-rs/src/core/types/record.rs
@@ -5,9 +5,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::str::FromStr;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, TypeTag};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::Argument;
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use serde::{Deserialize, Serialize};
 
 use crate::core::internal::tx;
@@ -83,7 +83,7 @@ impl InitialRecord {
         }
     }
 
-    pub(crate) fn tag(package_id: ObjectID) -> TypeTag {
+    pub(crate) fn tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(&format!(
             "{package_id}::record::InitialRecord<{}>",
             Data::tag(package_id)
@@ -91,7 +91,7 @@ impl InitialRecord {
         .expect("invalid TypeTag for InitialRecord")
     }
 
-    pub(in crate::core) fn into_ptb(self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn into_ptb(self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         let data_tag = Data::tag(package_id);
         let data = self.data.into_ptb(ptb, package_id)?;
         let metadata = tx::ptb_pure(ptb, "initial_record_metadata", self.metadata)?;
@@ -162,12 +162,12 @@ pub enum Data {
 
 impl Data {
     /// Returns the Move type tag for `record::Data`.
-    pub(crate) fn tag(package_id: ObjectID) -> TypeTag {
+    pub(crate) fn tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(&format!("{package_id}::record::Data")).expect("should be valid type tag")
     }
 
     /// Creates a PTB argument for `record::Data`.
-    pub(in crate::core) fn into_ptb(self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn into_ptb(self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         match self {
             Data::Bytes(bytes) => {
                 let bytes = tx::ptb_pure(ptb, "data_bytes", bytes)?;
@@ -193,7 +193,7 @@ impl Data {
     }
 
     /// Validates that the on-chain trail stores `record::Data`.
-    pub(in crate::core) fn ensure_matches_tag(&self, expected: &TypeTag, package_id: ObjectID) -> Result<(), Error> {
+    pub(in crate::core) fn ensure_matches_tag(&self, expected: &TypeTag, package_id: ObjectId) -> Result<(), Error> {
         let actual = Self::tag(package_id);
 
         if &actual == expected {

--- a/audit-trail-rs/src/core/types/role_map.rs
+++ b/audit-trail-rs/src/core/types/role_map.rs
@@ -4,12 +4,12 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, TypeTag};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::collection_types::LinkedTable;
 use iota_interaction::types::id::UID;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use serde::{Deserialize, Serialize};
 use serde_aux::field_attributes::deserialize_option_number_from_string;
 
@@ -25,7 +25,7 @@ use crate::error::Error;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoleMap {
     /// Trail object ID that this role map protects.
-    pub target_key: ObjectID,
+    pub target_key: ObjectId,
     /// Role definitions keyed by role name.
     #[serde(deserialize_with = "deserialize_vec_map")]
     pub roles: HashMap<String, Role>,
@@ -33,10 +33,10 @@ pub struct RoleMap {
     /// Move `INITIAL_ADMIN_ROLE_NAME` constant). The role bearing this name cannot be deleted.
     pub initial_admin_role_name: String,
     /// Denylist of revoked capability IDs.
-    pub revoked_capabilities: LinkedTable<ObjectID>,
+    pub revoked_capabilities: LinkedTable<ObjectId>,
     /// Capability IDs currently recognized as initial-admin capabilities.
     #[serde(deserialize_with = "deserialize_vec_set")]
-    pub initial_admin_cap_ids: HashSet<ObjectID>,
+    pub initial_admin_cap_ids: HashSet<ObjectId>,
     /// Permissions required to administer roles.
     pub role_admin_permissions: RoleAdminPermissions,
     /// Permissions required to administer capabilities.
@@ -121,11 +121,11 @@ impl RoleTags {
         self.tags.contains(tag)
     }
 
-    pub(crate) fn tag(package_id: ObjectID) -> TypeTag {
+    pub(crate) fn tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(&format!("{package_id}::record_tags::RoleTags")).expect("invalid TypeTag for RoleTags")
     }
 
-    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         let mut tags = self.tags.iter().cloned().collect::<Vec<_>>();
         tags.sort();
         let tags_arg = tx::ptb_pure(ptb, "tags", tags)?;
@@ -149,7 +149,7 @@ pub struct Capability {
     /// Capability object ID.
     pub id: UID,
     /// Trail object ID protected by the capability.
-    pub target_key: ObjectID,
+    pub target_key: ObjectId,
     /// Role granted by the capability.
     pub role: String,
     /// Address bound to the capability. When `None`, any holder may present the capability for
@@ -166,17 +166,17 @@ pub struct Capability {
 }
 
 impl Capability {
-    pub(crate) fn type_tag(package_id: ObjectID) -> TypeTag {
+    pub(crate) fn type_tag(package_id: ObjectId) -> TypeTag {
         TypeTag::from_str(format!("{package_id}::capability::Capability").as_str()).expect("failed to create type tag")
     }
 
-    pub(crate) fn matches_target_and_role(&self, trail_id: ObjectID, valid_roles: &HashSet<String>) -> bool {
+    pub(crate) fn matches_target_and_role(&self, trail_id: ObjectId, valid_roles: &HashSet<String>) -> bool {
         self.target_key == trail_id && valid_roles.contains(&self.role)
     }
 }
 
 impl MoveType for Capability {
-    fn move_type(package: ObjectID) -> TypeTag {
+    fn move_type(package: ObjectId) -> TypeTag {
         Self::type_tag(package)
     }
 }

--- a/audit-trail-rs/src/package.rs
+++ b/audit-trail-rs/src/package.rs
@@ -10,7 +10,7 @@
 
 use std::sync::LazyLock;
 
-use iota_interaction::types::base_types::ObjectID;
+use iota_sdk_types::ObjectId;
 use product_common::network_name::NetworkName;
 use product_common::package_registry::{Env, PackageRegistry};
 use product_common::tf_components_registry;
@@ -66,8 +66,8 @@ pub(crate) fn blocking_audit_trail_registry_mut() -> PackageRegistryLockMut {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ResolvedPackageIds {
-    pub audit_trail_package_id: ObjectID,
-    pub tf_components_package_id: ObjectID,
+    pub audit_trail_package_id: ObjectId,
+    pub tf_components_package_id: ObjectId,
 }
 
 pub(crate) async fn resolve_package_ids(
@@ -130,7 +130,7 @@ mod tests {
         let network = NetworkName::try_from("testnet").expect("valid network");
         let registry_package_id = tf_components_registry::tf_components_package_id("testnet")
             .expect("testnet TfComponents package is in the registry");
-        let override_package_id = ObjectID::random();
+        let override_package_id = ObjectId::random();
 
         let (_, registry_resolved_package_ids) = resolve_package_ids(&network, &PackageOverrides::default())
             .await
@@ -144,7 +144,7 @@ mod tests {
         let (_, resolved_package_ids) = resolve_package_ids(
             &network,
             &PackageOverrides {
-                audit_trail: Some(ObjectID::random()),
+                audit_trail: Some(ObjectId::random()),
                 tf_component: Some(override_package_id),
             },
         )

--- a/audit-trail-rs/tests/e2e/client.rs
+++ b/audit-trail-rs/tests/e2e/client.rs
@@ -12,10 +12,11 @@ use audit_trails::core::types::{
     RoleTags,
 };
 use audit_trails::{AuditTrailClient, PackageOverrides};
-use iota_interaction::types::base_types::{IotaAddress, ObjectID, ObjectRef};
+use iota_interaction::types::base_types::{IotaAddress, ObjectRef};
 use iota_interaction::types::crypto::PublicKey;
 use iota_interaction::{IOTA_LOCAL_NETWORK_URL, IotaClient, IotaClientBuilder};
 use iota_interaction_rust::IotaClientAdapter;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::network_name::NetworkName;
 use product_common::test_utils::{InMemSigner, request_funds};
@@ -35,8 +36,8 @@ const CACHED_PKG_FILE: &str = "/tmp/audit_trail_pkg_ids.txt";
 
 #[derive(Clone, Copy)]
 struct PublishedPackageIds {
-    audit_trail_package_id: ObjectID,
-    tf_components_package_id: Option<ObjectID>,
+    audit_trail_package_id: ObjectId,
+    tf_components_package_id: Option<ObjectId>,
 }
 
 pub async fn get_funded_test_client() -> anyhow::Result<TestClient> {
@@ -57,13 +58,13 @@ async fn load_cached_package_ids(chain_id: &str) -> anyhow::Result<PublishedPack
     }
 
     Ok(PublishedPackageIds {
-        audit_trail_package_id: ObjectID::from_str(audit_trail_package_id)
+        audit_trail_package_id: ObjectId::from_str(audit_trail_package_id)
             .context("failed to parse cached IotaAuditTrails package ID")?,
         tf_components_package_id: if tf_components_package_id.is_empty() {
             None
         } else {
             Some(
-                ObjectID::from_str(tf_components_package_id)
+                ObjectId::from_str(tf_components_package_id)
                     .context("failed to parse cached TfComponents package ID")?,
             )
         },
@@ -108,12 +109,12 @@ async fn publish_package_ids(iota_client: &IotaClient) -> anyhow::Result<Publish
         match key {
             "IOTA_AUDIT_TRAIL_PKG_ID" => {
                 let package_id =
-                    ObjectID::from_str(value).context("failed to parse published IotaAuditTrails package ID")?;
+                    ObjectId::from_str(value).context("failed to parse published IotaAuditTrails package ID")?;
                 audit_trail_package_id = Some(package_id);
             }
             "IOTA_TF_COMPONENTS_PKG_ID" => {
                 let package_id =
-                    ObjectID::from_str(value).context("failed to parse published TfComponents package ID")?;
+                    ObjectId::from_str(value).context("failed to parse published TfComponents package ID")?;
                 tf_components_package_id = Some(package_id);
             }
             _ => {}
@@ -184,7 +185,7 @@ impl TestClient {
         })
     }
 
-    pub(crate) async fn get_cap(&self, owner: IotaAddress, trail_id: ObjectID) -> anyhow::Result<ObjectRef> {
+    pub(crate) async fn get_cap(&self, owner: IotaAddress, trail_id: ObjectId) -> anyhow::Result<ObjectRef> {
         let cap: Capability = self
             .client
             .find_object_for_address(owner, |cap: &Capability| cap.target_key == trail_id)
@@ -203,14 +204,14 @@ impl TestClient {
             .unwrap())
     }
 
-    /// Creates a trail with the given initial record data and returns its ObjectID.
-    pub(crate) async fn create_test_trail(&self, data: Data) -> anyhow::Result<ObjectID> {
+    /// Creates a trail with the given initial record data and returns its ObjectId.
+    pub(crate) async fn create_test_trail(&self, data: Data) -> anyhow::Result<ObjectId> {
         self.create_test_trail_with_tags(data, std::iter::empty::<String>())
             .await
     }
 
     /// Creates a trail with the given initial record data and available tags.
-    pub(crate) async fn create_test_trail_with_tags<I, S>(&self, data: Data, tags: I) -> anyhow::Result<ObjectID>
+    pub(crate) async fn create_test_trail_with_tags<I, S>(&self, data: Data, tags: I) -> anyhow::Result<ObjectId>
     where
         I: IntoIterator<Item = S>,
         S: Into<String>,
@@ -229,7 +230,7 @@ impl TestClient {
     /// Creates a role on the given trail with the specified permissions and optional role tags.
     pub(crate) async fn create_role(
         &self,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         role_name: &str,
         permissions: impl IntoIterator<Item = Permission>,
         role_tags: Option<RoleTags>,
@@ -253,7 +254,7 @@ impl TestClient {
     /// Issues a capability for the given role on the trail.
     pub(crate) async fn issue_cap(
         &self,
-        trail_id: ObjectID,
+        trail_id: ObjectId,
         role_name: &str,
         options: CapabilityIssueOptions,
     ) -> anyhow::Result<CapabilityIssued> {
@@ -270,11 +271,11 @@ impl TestClient {
 }
 
 impl CoreClientReadOnly for TestClient {
-    fn package_id(&self) -> ObjectID {
+    fn package_id(&self) -> ObjectId {
         self.client.package_id()
     }
 
-    fn tf_components_package_id(&self) -> Option<ObjectID> {
+    fn tf_components_package_id(&self) -> Option<ObjectId> {
         Some(self.client.tf_components_package_id())
     }
 

--- a/audit-trail-rs/tests/e2e/locking.rs
+++ b/audit-trail-rs/tests/e2e/locking.rs
@@ -4,13 +4,13 @@
 use audit_trails::core::types::{
     CapabilityIssueOptions, Data, InitialRecord, LockingConfig, LockingWindow, Permission, TimeLock,
 };
-use iota_interaction::types::base_types::ObjectID;
+use iota_sdk_types::ObjectId;
 
 use crate::client::{TestClient, get_funded_test_client};
 
 async fn grant_role_capability(
     client: &TestClient,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     role_name: &str,
     permissions: impl IntoIterator<Item = Permission>,
 ) -> anyhow::Result<()> {

--- a/audit-trail-rs/tests/e2e/records.rs
+++ b/audit-trail-rs/tests/e2e/records.rs
@@ -7,7 +7,7 @@ use audit_trails::core::types::{
     CapabilityIssueOptions, Data, InitialRecord, LockingConfig, LockingWindow, Permission, RoleTags, TimeLock,
 };
 use audit_trails::error::Error;
-use iota_interaction::types::base_types::ObjectID;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClient;
 use tokio::time::{Duration, sleep};
 
@@ -15,7 +15,7 @@ use crate::client::{TestClient, get_funded_test_client};
 
 async fn grant_role_capability(
     client: &TestClient,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     role_name: &str,
     permissions: impl IntoIterator<Item = Permission>,
 ) -> anyhow::Result<()> {

--- a/bindings/wasm/audit_trail_wasm/Cargo.toml
+++ b/bindings/wasm/audit_trail_wasm/Cargo.toml
@@ -20,10 +20,11 @@ anyhow = "1.0.95"
 audit_trails = { path = "../../../audit-trail-rs", default-features = false, features = ["gas-station", "default-http-client"] }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge" }
 js-sys = { version = "0.3.61" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }

--- a/bindings/wasm/audit_trail_wasm/Cargo.toml
+++ b/bindings/wasm/audit_trail_wasm/Cargo.toml
@@ -21,10 +21,10 @@ audit_trails = { path = "../../../audit-trail-rs", default-features = false, fea
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21" }
 js-sys = { version = "0.3.61" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", features = ["core-client", "transaction", "bindings", "binding-utils", "gas-station", "default-http-client"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/access.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/access.rs
@@ -3,9 +3,9 @@
 
 use anyhow::anyhow;
 use audit_trails::AuditTrailClient;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result};
+use iota_sdk_types::ObjectId;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_object_id};
 use product_common::bindings::WasmObjectID;
@@ -27,7 +27,7 @@ use crate::types::{WasmCapabilityIssueOptions, WasmPermissionSet, WasmRoleTags};
 #[wasm_bindgen(js_name = TrailAccess, inspectable)]
 pub struct WasmTrailAccess {
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
 }
 
 impl WasmTrailAccess {
@@ -229,7 +229,7 @@ impl WasmTrailAccess {
 #[wasm_bindgen(js_name = RoleHandle, inspectable)]
 pub struct WasmRoleHandle {
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
     pub(crate) name: String,
 }
 

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/locking.rs
@@ -3,9 +3,9 @@
 
 use anyhow::anyhow;
 use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
+use iota_sdk_types::ObjectId;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::into_transaction_builder;
 use wasm_bindgen::prelude::*;
@@ -25,7 +25,7 @@ use crate::types::{WasmLockingConfig, WasmLockingWindow, WasmTimeLock};
 pub struct WasmTrailLocking {
     pub(crate) read_only: AuditTrailClientReadOnly,
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
 }
 
 impl WasmTrailLocking {

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/mod.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/mod.rs
@@ -11,9 +11,9 @@ mod tags;
 pub(crate) use access::WasmTrailAccess;
 use anyhow::anyhow;
 use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
+use iota_sdk_types::ObjectId;
 pub(crate) use locking::WasmTrailLocking;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::into_transaction_builder;
@@ -36,11 +36,11 @@ use crate::trail::{WasmDeleteAuditTrail, WasmMigrate, WasmOnChainAuditTrail, Was
 pub struct WasmAuditTrailHandle {
     pub(crate) read_only: AuditTrailClientReadOnly,
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
 }
 
 impl WasmAuditTrailHandle {
-    pub(crate) fn from_read_only(read_only: AuditTrailClientReadOnly, trail_id: ObjectID) -> Self {
+    pub(crate) fn from_read_only(read_only: AuditTrailClientReadOnly, trail_id: ObjectId) -> Self {
         Self {
             read_only,
             full: None,
@@ -48,7 +48,7 @@ impl WasmAuditTrailHandle {
         }
     }
 
-    pub(crate) fn from_full(full: AuditTrailClient<WasmTransactionSigner>, trail_id: ObjectID) -> Self {
+    pub(crate) fn from_full(full: AuditTrailClient<WasmTransactionSigner>, trail_id: ObjectId) -> Self {
         Self {
             read_only: full.read_only().clone(),
             full: Some(full),

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/records.rs
@@ -4,9 +4,9 @@
 use anyhow::anyhow;
 use audit_trails::core::types::Data as AuditTrailData;
 use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
+use iota_sdk_types::ObjectId;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::into_transaction_builder;
 use wasm_bindgen::prelude::*;
@@ -24,7 +24,7 @@ use crate::types::{WasmData, WasmEmpty, WasmPaginatedRecord, WasmRecord};
 pub struct WasmTrailRecords {
     pub(crate) read_only: AuditTrailClientReadOnly,
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
 }
 
 impl WasmTrailRecords {

--- a/bindings/wasm/audit_trail_wasm/src/trail_handle/tags.rs
+++ b/bindings/wasm/audit_trail_wasm/src/trail_handle/tags.rs
@@ -3,9 +3,9 @@
 
 use anyhow::anyhow;
 use audit_trails::{AuditTrailClient, AuditTrailClientReadOnly};
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmTransactionSigner;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
+use iota_sdk_types::ObjectId;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::into_transaction_builder;
 use wasm_bindgen::prelude::*;
@@ -23,7 +23,7 @@ use crate::types::WasmRecordTagEntry;
 pub struct WasmTrailTags {
     pub(crate) read_only: AuditTrailClientReadOnly,
     pub(crate) full: Option<AuditTrailClient<WasmTransactionSigner>>,
-    pub(crate) trail_id: ObjectID,
+    pub(crate) trail_id: ObjectId,
 }
 
 impl WasmTrailTags {

--- a/bindings/wasm/audit_trail_wasm/src/types.rs
+++ b/bindings/wasm/audit_trail_wasm/src/types.rs
@@ -11,8 +11,8 @@ use audit_trails::core::types::{
     RevokedCapabilitiesCleanedUp, Role, RoleAdminPermissions, RoleCreated, RoleDeleted, RoleMap, RoleTags, RoleUpdated,
     TimeLock,
 };
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::collection_types::LinkedTable;
+use iota_sdk_types::ObjectId;
 use js_sys::Uint8Array;
 use product_common::bindings::WasmIotaAddress;
 use serde::{Deserialize, Serialize};
@@ -149,13 +149,13 @@ fn sorted_tag_names(tags: HashSet<String>) -> Vec<String> {
     tags
 }
 
-fn sorted_object_ids(ids: HashSet<iota_interaction::types::base_types::ObjectID>) -> Vec<String> {
+fn sorted_object_ids(ids: HashSet<ObjectId>) -> Vec<String> {
     let mut ids: Vec<_> = ids.into_iter().map(|id| id.to_string()).collect();
     ids.sort_unstable();
     ids
 }
 
-fn optional_object_id(id: Option<ObjectID>) -> Option<String> {
+fn optional_object_id(id: Option<ObjectId>) -> Option<String> {
     id.map(|id| id.to_string())
 }
 
@@ -618,8 +618,8 @@ pub struct WasmObjectIdLinkedTable {
     pub tail: Option<String>,
 }
 
-impl From<LinkedTable<ObjectID>> for WasmObjectIdLinkedTable {
-    fn from(value: LinkedTable<ObjectID>) -> Self {
+impl From<LinkedTable<ObjectId>> for WasmObjectIdLinkedTable {
+    fn from(value: LinkedTable<ObjectId>) -> Self {
         Self {
             id: value.id.to_string(),
             size: value.size,

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -22,8 +22,8 @@ bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.21" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -38,7 +38,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-25-rc-upstream-merge"
+tag = "v0.8.21"
 features = [
   "core-client",
   "transaction",

--- a/bindings/wasm/notarization_wasm/Cargo.toml
+++ b/bindings/wasm/notarization_wasm/Cargo.toml
@@ -21,8 +21,9 @@ async-trait = { version = "0.1", default-features = false }
 bcs = "0.1.6"
 console_error_panic_hook = { version = "0.1" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "35a27488b887e28e844a1e46d7edb78605871155", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-25-rc-upstream-merge" }
 js-sys = { version = "=0.3.85" }
 prefix-hex = { version = "0.7", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -37,7 +38,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.20"
+branch = "feat/iota-v1-25-rc-upstream-merge"
 features = [
   "core-client",
   "transaction",

--- a/bindings/wasm/notarization_wasm/src/wasm_notarization_client.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_notarization_client.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::{WasmIotaClient, WasmPublicKey, WasmTransactionSigner};
 use iota_interaction_ts::wasm_error::{Result, WasmResult};
+use iota_sdk_types::ObjectId;
 use notarization::NotarizationClient;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_iota_address, parse_wasm_object_id};
@@ -87,7 +87,7 @@ impl WasmNotarizationClient {
     /// @returns Stringified object ID of the resolved `tf_components` package.
     #[wasm_bindgen(js_name = tfComponentsPackageId)]
     pub fn tf_components_package_id(&self) -> String {
-        self.0.tf_components_package_id().unwrap_or(ObjectID::ZERO).to_string()
+        self.0.tf_components_package_id().unwrap_or(ObjectId::ZERO).to_string()
     }
 
     /// The full history of notarization package IDs known on this network,

--- a/bindings/wasm/notarization_wasm/src/wasm_notarization_client_read_only.rs
+++ b/bindings/wasm/notarization_wasm/src/wasm_notarization_client_read_only.rs
@@ -4,9 +4,9 @@
 use std::str::FromStr;
 
 use anyhow::anyhow;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::bindings::WasmIotaClient;
 use iota_interaction_ts::wasm_error::{wasm_error, Result, WasmResult};
+use iota_sdk_types::ObjectId;
 use notarization::NotarizationClientReadOnly;
 use product_common::bindings::utils::parse_wasm_object_id;
 use product_common::bindings::WasmObjectID;
@@ -65,7 +65,7 @@ impl WasmNotarizationClientReadOnly {
     ) -> Result<WasmNotarizationClientReadOnly> {
         let inner_client = NotarizationClientReadOnly::new_with_pkg_id(
             iota_client,
-            ObjectID::from_str(&iota_notarization_pkg_id)
+            ObjectId::from_str(&iota_notarization_pkg_id)
                 .map_err(|e| anyhow!("Could not parse iota_notarization_pkg_id: {}", e.to_string()))
                 .wasm_result()?,
         )
@@ -85,7 +85,7 @@ impl WasmNotarizationClientReadOnly {
     /// @returns Stringified object ID of the resolved `tf_components` package.
     #[wasm_bindgen(js_name = tfComponentsPackageId)]
     pub fn tf_components_package_id(&self) -> String {
-        self.0.tf_components_package_id().unwrap_or(ObjectID::ZERO).to_string()
+        self.0.tf_components_package_id().unwrap_or(ObjectId::ZERO).to_string()
     }
 
     /// The full history of notarization package IDs known on this network,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -107,10 +107,11 @@ path = "audit-trail/real-world/03_digital_product_passport.rs"
 [dependencies]
 anyhow.workspace = true
 audit_trails = { path = "../audit-trail-rs" }
-chrono = { workspace = true }
-iota-sdk = { workspace = true }
+chrono.workspace = true
+iota-sdk.workspace = true
+iota-sdk-types.workspace = true
 notarization = { path = "../notarization-rs" }
 product_common = { workspace = true, features = ["core-client", "test-utils", "transaction"] }
-serde_json = { workspace = true }
-sha2 = { workspace = true }
-tokio = { workspace = true }
+serde_json.workspace = true
+sha2.workspace = true
+tokio.workspace = true

--- a/examples/audit-trail/real-world/03_digital_product_passport.rs
+++ b/examples/audit-trail/real-world/03_digital_product_passport.rs
@@ -42,7 +42,8 @@ use audit_trails::core::types::{
     CapabilityIssueOptions, Data, ImmutableMetadata, InitialRecord, PermissionSet, RoleTags,
 };
 use examples::{get_funded_audit_trail_client, issue_tagged_record_role};
-use iota_sdk::types::base_types::{IotaAddress, ObjectID};
+use iota_sdk::types::base_types::IotaAddress;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClient;
 use product_common::test_utils::InMemSigner;
 
@@ -429,7 +430,7 @@ async fn main() -> Result<()> {
 
 async fn issue_metadata_role(
     admin_client: &AuditTrailClient<InMemSigner>,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     role_name: &str,
     issued_to: IotaAddress,
 ) -> Result<()> {

--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -4,8 +4,9 @@
 use anyhow::Context;
 use audit_trails::core::types::{CapabilityIssueOptions, PermissionSet, RoleTags};
 use audit_trails::{AuditTrailClient, PackageOverrides};
-use iota_sdk::types::base_types::{IotaAddress, ObjectID};
+use iota_sdk::types::base_types::IotaAddress;
 use iota_sdk::{IOTA_LOCAL_NETWORK_URL, IotaClientBuilder};
+use iota_sdk_types::ObjectId;
 use notarization::client::{NotarizationClient, NotarizationClientReadOnly};
 use product_common::test_utils::{InMemSigner, request_funds};
 
@@ -17,7 +18,7 @@ async fn get_iota_client() -> anyhow::Result<iota_sdk::IotaClient> {
         .map_err(|err| anyhow::anyhow!("failed to connect to network; {}", err))
 }
 
-fn get_package_id_from_env(env_var_name: &str) -> anyhow::Result<ObjectID> {
+fn get_package_id_from_env(env_var_name: &str) -> anyhow::Result<ObjectId> {
     let value = std::env::var(env_var_name)
         .with_context(|| format!("env variable '{env_var_name}' must be set in order to run the examples"))?;
 
@@ -78,7 +79,7 @@ pub async fn get_funded_audit_trail_client() -> Result<AuditTrailClient<InMemSig
 
 pub async fn issue_tagged_record_role(
     client: &AuditTrailClient<InMemSigner>,
-    trail_id: ObjectID,
+    trail_id: ObjectId,
     role_name: &str,
     tag: &str,
     issued_to: IotaAddress,

--- a/notarization-rs/Cargo.toml
+++ b/notarization-rs/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 iota-caip = { git = "https://github.com/iotaledger/iota-caip.git", default-features = false, features = ["iota"], optional = true }
+iota-sdk-types.workspace = true
 iota_interaction = { workspace = true, default-features = false }
 product_common = { workspace = true, default-features = false, features = ["transaction"] }
 secret-storage = { workspace = true, default-features = false }

--- a/notarization-rs/src/client/full_client.rs
+++ b/notarization-rs/src/client/full_client.rs
@@ -17,9 +17,9 @@
 //! ```rust,ignore
 //! # use notarization::client::full_client::NotarizationClient;
 //! # use notarization::core::types::State;
-//! # use iota_interaction::types::base_types::ObjectID;
+//! # use iota_sdk_types::ObjectId;
 //! # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>) -> Result<(), Box<dyn std::error::Error>> {
-//! # let notarization_id = ObjectID::ZERO;
+//! # let notarization_id = ObjectId::ZERO;
 //! // 1. Create the transaction
 //! let result = client
 //!     .update_state(State::from_string("New data".to_string(), None), notarization_id)
@@ -79,9 +79,10 @@
 
 use std::ops::Deref;
 
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::crypto::PublicKey;
 use iota_interaction::{IotaKeySignature, OptionalSync};
+use iota_sdk_types::ObjectId;
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::network_name::NetworkName;
 use product_common::transaction::transaction_builder::TransactionBuilder;
@@ -254,8 +255,8 @@ where
     /// ```rust,ignore
     /// # use notarization::client::full_client::NotarizationClient;
     /// # use notarization::core::types::State;
-    /// # use iota_interaction::types::base_types::ObjectID;
-    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectID) -> Result<(), Box<dyn std::error::Error>> {
+    /// # use iota_sdk_types::ObjectId;
+    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectId) -> Result<(), Box<dyn std::error::Error>> {
     /// client
     ///     .update_state(
     ///         State::from_string("Status: Completed", Some("Final version")),
@@ -268,7 +269,7 @@ where
     /// ```
     ///
     /// Returns a [`TransactionBuilder`]. See [module docs](self) for transaction flow.
-    pub fn update_state(&self, new_state: State, notarization_id: ObjectID) -> TransactionBuilder<UpdateState> {
+    pub fn update_state(&self, new_state: State, notarization_id: ObjectId) -> TransactionBuilder<UpdateState> {
         TransactionBuilder::new(UpdateState::new(new_state, notarization_id))
     }
 
@@ -291,8 +292,8 @@ where
     ///
     /// ```rust,ignore
     /// # use notarization::client::full_client::NotarizationClient;
-    /// # use iota_interaction::types::base_types::ObjectID;
-    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectID) -> Result<(), Box<dyn std::error::Error>> {
+    /// # use iota_sdk_types::ObjectId;
+    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectId) -> Result<(), Box<dyn std::error::Error>> {
     /// client
     ///     .destroy(notarization_id)
     ///     .build_and_execute(&client)
@@ -302,7 +303,7 @@ where
     /// ```
     ///
     /// Returns a [`TransactionBuilder`]. See [module docs](self) for transaction flow.
-    pub fn destroy(&self, notarization_id: ObjectID) -> TransactionBuilder<DestroyNotarization> {
+    pub fn destroy(&self, notarization_id: ObjectId) -> TransactionBuilder<DestroyNotarization> {
         TransactionBuilder::new(DestroyNotarization::new(notarization_id))
     }
 
@@ -326,8 +327,8 @@ where
     ///
     /// ```rust,ignore
     /// # use notarization::NotarizationClient;
-    /// # use iota_interaction::types::base_types::ObjectID;
-    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectID) -> Result<(), Box<dyn std::error::Error>> {
+    /// # use iota_sdk_types::ObjectId;
+    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectId) -> Result<(), Box<dyn std::error::Error>> {
     /// client
     ///     .update_metadata(
     ///         Some("Reviewed by legal team".to_string()),
@@ -343,7 +344,7 @@ where
     pub fn update_metadata(
         &self,
         metadata: Option<String>,
-        notarization_id: ObjectID,
+        notarization_id: ObjectId,
     ) -> TransactionBuilder<UpdateMetadata> {
         TransactionBuilder::new(UpdateMetadata::new(metadata, notarization_id))
     }
@@ -371,8 +372,8 @@ where
     ///
     /// ```rust,ignore
     /// # use notarization::client::full_client::NotarizationClient;
-    /// # use iota_interaction::types::base_types::{ObjectID, IotaAddress};
-    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectID, recipient: IotaAddress) -> Result<(), Box<dyn std::error::Error>> {
+    /// # use iota_interaction::types::base_types::{ObjectId, IotaAddress};
+    /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectId, recipient: IotaAddress) -> Result<(), Box<dyn std::error::Error>> {
     /// client
     ///     .transfer_notarization(notarization_id, recipient)
     ///     .build_and_execute(&client)
@@ -384,7 +385,7 @@ where
     /// Returns a [`TransactionBuilder`]. See [module docs](self) for transaction flow.
     pub fn transfer_notarization(
         &self,
-        notarization_id: ObjectID,
+        notarization_id: ObjectId,
         recipient: IotaAddress,
     ) -> TransactionBuilder<TransferNotarization> {
         TransactionBuilder::new(TransferNotarization::new(recipient, notarization_id))
@@ -399,7 +400,7 @@ where
         &self.read_client
     }
 
-    fn package_id(&self) -> ObjectID {
+    fn package_id(&self) -> ObjectId {
         self.read_client.package_id()
     }
 

--- a/notarization-rs/src/client/full_client.rs
+++ b/notarization-rs/src/client/full_client.rs
@@ -372,7 +372,8 @@ where
     ///
     /// ```rust,ignore
     /// # use notarization::client::full_client::NotarizationClient;
-    /// # use iota_interaction::types::base_types::{ObjectId, IotaAddress};
+    /// # use iota_interaction::types::base_types::IotaAddress;
+    /// # use iota_sdk_types::ObjectId;
     /// # async fn example(client: &NotarizationClient<impl secret_storage::Signer<iota_interaction::IotaKeySignature>>, notarization_id: ObjectId, recipient: IotaAddress) -> Result<(), Box<dyn std::error::Error>> {
     /// client
     ///     .transfer_notarization(notarization_id, recipient)

--- a/notarization-rs/src/client/read_only.rs
+++ b/notarization-rs/src/client/read_only.rs
@@ -11,10 +11,11 @@ use std::ops::Deref;
 #[cfg(not(target_arch = "wasm32"))]
 use iota_interaction::IotaClient;
 use iota_interaction::IotaClientTrait;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::{ProgrammableTransaction, TransactionKind};
 #[cfg(target_arch = "wasm32")]
 use iota_interaction_ts::bindings::WasmIotaClient;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::network_name::NetworkName;
 use product_common::package_registry::Env;
@@ -39,9 +40,9 @@ use crate::package;
 pub struct NotarizationClientReadOnly {
     /// The underlying IOTA client adapter used for communication.
     iota_client: IotaClientAdapter,
-    /// The [`ObjectID`] of the deployed Notarization package (smart contract).
+    /// The [`ObjectId`] of the deployed Notarization package (smart contract).
     /// All interactions go through this package ID.
-    notarization_pkg_id: ObjectID,
+    notarization_pkg_id: ObjectId,
     /// The name of the network this client is connected to (e.g., "mainnet", "testnet").
     network: NetworkName,
     chain_id: String,
@@ -147,14 +148,14 @@ impl NotarizationClientReadOnly {
     /// # Arguments
     ///
     /// * `iota_client`: The IOTA client instance.
-    /// * `package_id`: The specific [`ObjectID`] of the Notarization package to use.
+    /// * `package_id`: The specific [`ObjectId`] of the Notarization package to use.
     ///
     /// # Returns
     /// A `Result` containing the initialized [`NotarizationClientReadOnly`] or an [`Error`].
     pub async fn new_with_pkg_id(
         #[cfg(target_arch = "wasm32")] iota_client: WasmIotaClient,
         #[cfg(not(target_arch = "wasm32"))] iota_client: IotaClient,
-        package_id: ObjectID,
+        package_id: ObjectId,
     ) -> Result<Self, Error> {
         let client = IotaClientAdapter::new(iota_client);
         let network = network_id(&client).await?;
@@ -174,11 +175,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the [`OnChainNotarization`] or an [`Error`].
-    pub async fn get_notarization_by_id(&self, notarized_object_id: ObjectID) -> Result<OnChainNotarization, Error> {
+    pub async fn get_notarization_by_id(&self, notarized_object_id: ObjectId) -> Result<OnChainNotarization, Error> {
         let (mut notarization, address) = get_notarization_with_owner(self, &notarized_object_id).await?;
         notarization.owner = address;
 
@@ -191,11 +192,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the timestamp as a `u64` or an [`Error`].
-    pub async fn last_state_change_ts(&self, notarized_object_id: ObjectID) -> Result<u64, Error> {
+    pub async fn last_state_change_ts(&self, notarized_object_id: ObjectId) -> Result<u64, Error> {
         let tx = NotarizationImpl::last_change_ts(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -207,11 +208,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the timestamp as a `u64` or an [`Error`].
-    pub async fn created_at_ts(&self, notarized_object_id: ObjectID) -> Result<u64, Error> {
+    pub async fn created_at_ts(&self, notarized_object_id: ObjectId) -> Result<u64, Error> {
         let tx = NotarizationImpl::created_at(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -223,11 +224,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the version count as a `u64` or an [`Error`].
-    pub async fn state_version_count(&self, notarized_object_id: ObjectID) -> Result<u64, Error> {
+    pub async fn state_version_count(&self, notarized_object_id: ObjectId) -> Result<u64, Error> {
         let tx = NotarizationImpl::version_count(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -239,11 +240,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing an `Option<String>` or an [`Error`]. `None` if no description is set.
-    pub async fn description(&self, notarized_object_id: ObjectID) -> Result<Option<String>, Error> {
+    pub async fn description(&self, notarized_object_id: ObjectId) -> Result<Option<String>, Error> {
         let tx = NotarizationImpl::description(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -259,11 +260,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing an `Option<String>` or an [`Error`]. `None` if no updatable metadata is set.
-    pub async fn updatable_metadata(&self, notarized_object_id: ObjectID) -> Result<Option<String>, Error> {
+    pub async fn updatable_metadata(&self, notarized_object_id: ObjectId) -> Result<Option<String>, Error> {
         let tx = NotarizationImpl::updatable_metadata(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -276,11 +277,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the [`NotarizationMethod`] or an [`Error`].
-    pub async fn notarization_method(&self, notarized_object_id: ObjectID) -> Result<NotarizationMethod, Error> {
+    pub async fn notarization_method(&self, notarized_object_id: ObjectId) -> Result<NotarizationMethod, Error> {
         let tx = NotarizationImpl::notarization_method(notarized_object_id, self).await?;
         self.execute_read_only_transaction(tx).await
     }
@@ -291,11 +292,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing an `Option<LockMetadata>` or an [`Error`]. `None` if no locks are set.
-    pub async fn lock_metadata(&self, notarized_object_id: ObjectID) -> Result<Option<LockMetadata>, Error> {
+    pub async fn lock_metadata(&self, notarized_object_id: ObjectId) -> Result<Option<LockMetadata>, Error> {
         let tx = NotarizationImpl::lock_metadata(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -312,11 +313,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the [`State<Data>`] or an [`Error`].
-    pub async fn state(&self, notarized_object_id: ObjectID) -> Result<State, Error> {
+    pub async fn state(&self, notarized_object_id: ObjectId) -> Result<State, Error> {
         let type_tag = move_utils::get_type_tag(self, &notarized_object_id).await?;
         let type_str = type_tag.to_string();
 
@@ -344,11 +345,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing the [`State<T>`] or an [`Error`].
-    pub async fn state_as<T: DeserializeOwned>(&self, notarized_object_id: ObjectID) -> Result<State<T>, Error> {
+    pub async fn state_as<T: DeserializeOwned>(&self, notarized_object_id: ObjectId) -> Result<State<T>, Error> {
         let tx = NotarizationImpl::state(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -363,11 +364,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing `true` if the object is update-locked, `false` otherwise, or an [`Error`].
-    pub async fn is_update_locked(&self, notarized_object_id: ObjectID) -> Result<bool, Error> {
+    pub async fn is_update_locked(&self, notarized_object_id: ObjectId) -> Result<bool, Error> {
         let tx = NotarizationImpl::is_update_locked(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -383,11 +384,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing `true` if the object is destroy-allowed, `false` otherwise, or an [`Error`].
-    pub async fn is_destroy_allowed(&self, notarized_object_id: ObjectID) -> Result<bool, Error> {
+    pub async fn is_destroy_allowed(&self, notarized_object_id: ObjectId) -> Result<bool, Error> {
         let tx = NotarizationImpl::is_destroy_allowed(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -402,11 +403,11 @@ impl NotarizationClientReadOnly {
     ///
     /// # Arguments
     ///
-    /// * `notarized_object_id`: The [`ObjectID`] of the notarized object.
+    /// * `notarized_object_id`: The [`ObjectId`] of the notarized object.
     ///
     /// # Returns
     /// A `Result` containing `true` if the object is transfer-locked, `false` otherwise, or an [`Error`].
-    pub async fn is_transfer_locked(&self, notarized_object_id: ObjectID) -> Result<bool, Error> {
+    pub async fn is_transfer_locked(&self, notarized_object_id: ObjectId) -> Result<bool, Error> {
         let tx = NotarizationImpl::is_transfer_locked(notarized_object_id, self).await?;
 
         self.execute_read_only_transaction(tx).await
@@ -458,8 +459,8 @@ impl NotarizationClientReadOnly {
 
 #[async_trait::async_trait]
 impl CoreClientReadOnly for NotarizationClientReadOnly {
-    /// Returns the [`ObjectID`] of the Notarization package used by this client.
-    fn package_id(&self) -> ObjectID {
+    /// Returns the [`ObjectId`] of the Notarization package used by this client.
+    fn package_id(&self) -> ObjectId {
         self.notarization_pkg_id
     }
 

--- a/notarization-rs/src/core/move_utils.rs
+++ b/notarization-rs/src/core/move_utils.rs
@@ -4,11 +4,12 @@
 use std::str::FromStr;
 
 use iota_interaction::rpc_types::IotaObjectDataOptions;
-use iota_interaction::types::base_types::{ObjectID, ObjectRef, TypeTag};
+use iota_interaction::types::base_types::ObjectRef;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::{Argument, CallArg, SharedObjectRef};
+use iota_interaction::types::transaction::{CallArg, SharedObjectRef};
 use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION};
 use iota_interaction::{IotaClientTrait, OptionalSync};
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use product_common::core_client::CoreClientReadOnly;
 use serde::Serialize;
 
@@ -36,7 +37,7 @@ where
 }
 
 /// Get the type tag of an object
-pub(crate) async fn get_type_tag<C>(client: &C, object_id: &ObjectID) -> Result<TypeTag, Error>
+pub(crate) async fn get_type_tag<C>(client: &C, object_id: &ObjectId) -> Result<TypeTag, Error>
 where
     C: CoreClientReadOnly + OptionalSync,
 {
@@ -85,7 +86,7 @@ pub(crate) fn parse_type(full_type: &str) -> Result<String, Error> {
 
 pub(crate) async fn get_object_ref_by_id(
     iota_client: &impl CoreClientReadOnly,
-    obj: &ObjectID,
+    obj: &ObjectId,
 ) -> Result<ObjectRef, Error> {
     let res = iota_client
         .client_adapter()

--- a/notarization-rs/src/core/operations.rs
+++ b/notarization-rs/src/core/operations.rs
@@ -12,10 +12,11 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use iota_interaction::types::base_types::{Identifier, IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_interaction::types::transaction::{Argument, CallArg, ProgrammableTransaction};
+use iota_interaction::types::transaction::{CallArg, ProgrammableTransaction};
 use iota_interaction::{OptionalSync, ident_str};
+use iota_sdk_types::{Argument, Identifier, ObjectId};
 use product_common::core_client::CoreClientReadOnly;
 
 use super::move_utils;
@@ -48,7 +49,7 @@ impl NotarizationImpl {
     /// * Method name is invalid
     async fn build_transaction<C, F>(
         client: &C,
-        object_id: ObjectID,
+        object_id: ObjectId,
         method: impl AsRef<str>,
         additional_args: F,
     ) -> Result<ProgrammableTransaction, Error>
@@ -100,7 +101,7 @@ impl NotarizationImpl {
 pub(crate) trait NotarizationOperations {
     /// Build a transaction that creates a new locked notarization
     fn new_locked(
-        package_id: ObjectID,
+        package_id: ObjectId,
         state: State,
         immutable_description: Option<String>,
         updatable_metadata: Option<String>,
@@ -128,7 +129,7 @@ pub(crate) trait NotarizationOperations {
 
     /// Build a transaction that creates a new dynamic notarization
     fn new_dynamic(
-        package_id: ObjectID,
+        package_id: ObjectId,
         state: State,
         immutable_description: Option<String>,
         updatable_metadata: Option<String>,
@@ -163,7 +164,7 @@ pub(crate) trait NotarizationOperations {
     /// Build a transaction that updates the state of a notarization
     async fn update_state<C>(
         client: &C,
-        object_id: ObjectID,
+        object_id: ObjectId,
         new_state: State,
     ) -> Result<ProgrammableTransaction, Error>
     where
@@ -179,7 +180,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Build a transaction that destroys a notarization
-    async fn destroy<C>(client: &C, object_id: ObjectID) -> Result<ProgrammableTransaction, Error>
+    async fn destroy<C>(client: &C, object_id: ObjectId) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -192,7 +193,7 @@ pub(crate) trait NotarizationOperations {
     /// Build a transaction that updates the metadata of a notarization
     async fn update_metadata<C>(
         client: &C,
-        object_id: ObjectID,
+        object_id: ObjectId,
         new_metadata: Option<String>,
     ) -> Result<ProgrammableTransaction, Error>
     where
@@ -208,7 +209,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Build a transaction that returns the notarization method
-    async fn notarization_method<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn notarization_method<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -216,7 +217,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Build a transaction that checks if the notarization is locked for update
-    async fn is_update_locked<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn is_update_locked<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -227,7 +228,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Build a transaction that checks if the notarization is allowed to be destroyed
-    async fn is_destroy_allowed<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn is_destroy_allowed<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -238,7 +239,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Build a transaction that checks if the notarization is locked for transfer
-    async fn is_transfer_locked<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn is_transfer_locked<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -249,7 +250,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Last change timestamp
-    async fn last_change_ts<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn last_change_ts<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -257,7 +258,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Version count
-    async fn version_count<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn version_count<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -265,7 +266,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Created at timestamp
-    async fn created_at<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn created_at<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -273,7 +274,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Description
-    async fn description<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn description<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -281,7 +282,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Updatable metadata
-    async fn updatable_metadata<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn updatable_metadata<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -289,14 +290,14 @@ pub(crate) trait NotarizationOperations {
     }
 
     /// Lock metadata
-    async fn lock_metadata<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn lock_metadata<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
         NotarizationImpl::build_transaction(client, object_id, "lock_metadata", |_| Ok(vec![])).await
     }
 
-    async fn state<C>(object_id: ObjectID, client: &C) -> Result<ProgrammableTransaction, Error>
+    async fn state<C>(object_id: ObjectId, client: &C) -> Result<ProgrammableTransaction, Error>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
@@ -304,7 +305,7 @@ pub(crate) trait NotarizationOperations {
     }
 
     async fn transfer_notarization<C>(
-        object_id: ObjectID,
+        object_id: ObjectId,
         recipient: IotaAddress,
         client: &C,
     ) -> Result<ProgrammableTransaction, Error>

--- a/notarization-rs/src/core/transactions/create.rs
+++ b/notarization-rs/src/core/transactions/create.rs
@@ -23,10 +23,10 @@ use async_trait::async_trait;
 use iota_interaction::rpc_types::{
     IotaData as _, IotaObjectDataOptions, IotaTransactionBlockEffects, IotaTransactionBlockEvents,
 };
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
-use iota_interaction::types::object::Owner;
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
 use iota_interaction::{IotaClientTrait, OptionalSend, OptionalSync};
+use iota_sdk_types::{ObjectId, Owner};
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -234,7 +234,7 @@ impl<M: Clone + OptionalSend + OptionalSync> Transaction for CreateNotarization<
 /// A helper function to get the notarization with the owner.
 pub(crate) async fn get_notarization_with_owner(
     client: &impl CoreClientReadOnly,
-    object_id: &ObjectID,
+    object_id: &ObjectId,
 ) -> Result<(OnChainNotarization, IotaAddress), Error> {
     let data = client
         .client_adapter()

--- a/notarization-rs/src/core/transactions/destroy.rs
+++ b/notarization-rs/src/core/transactions/destroy.rs
@@ -16,8 +16,8 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -37,13 +37,13 @@ use crate::error::Error;
 ///
 /// Emits a `NotarizationDestroyed` event on success.
 pub struct DestroyNotarization {
-    notarization_id: ObjectID,
+    notarization_id: ObjectId,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl DestroyNotarization {
     /// Creates a new destroy transaction.
-    pub fn new(notarization_id: ObjectID) -> Self {
+    pub fn new(notarization_id: ObjectId) -> Self {
         Self {
             notarization_id,
             cached_ptb: OnceCell::new(),

--- a/notarization-rs/src/core/transactions/transfer.rs
+++ b/notarization-rs/src/core/transactions/transfer.rs
@@ -20,8 +20,9 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -45,13 +46,13 @@ use crate::error::Error;
 /// Emits a `DynamicNotarizationTransferred` event on success.
 pub struct TransferNotarization {
     recipient: IotaAddress,
-    notarization_id: ObjectID,
+    notarization_id: ObjectId,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl TransferNotarization {
     /// Creates a new transfer transaction.
-    pub fn new(recipient: IotaAddress, notarization_id: ObjectID) -> Self {
+    pub fn new(recipient: IotaAddress, notarization_id: ObjectId) -> Self {
         Self {
             recipient,
             notarization_id,

--- a/notarization-rs/src/core/transactions/update_metadata.rs
+++ b/notarization-rs/src/core/transactions/update_metadata.rs
@@ -17,8 +17,8 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -38,13 +38,13 @@ use crate::error::Error;
 pub struct UpdateMetadata {
     metadata: Option<String>,
     /// The ID of the notarization to update
-    notarization_id: ObjectID,
+    notarization_id: ObjectId,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
 impl UpdateMetadata {
     /// Creates a new transaction for updating the metadata of a notarization.
-    pub fn new(metadata: Option<String>, notarization_id: ObjectID) -> Self {
+    pub fn new(metadata: Option<String>, notarization_id: ObjectId) -> Self {
         Self {
             metadata,
             notarization_id,

--- a/notarization-rs/src/core/transactions/update_state.rs
+++ b/notarization-rs/src/core/transactions/update_state.rs
@@ -15,8 +15,8 @@
 use async_trait::async_trait;
 use iota_interaction::OptionalSync;
 use iota_interaction::rpc_types::IotaTransactionBlockEffects;
-use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::transaction::ProgrammableTransaction;
+use iota_sdk_types::ObjectId;
 use product_common::core_client::CoreClientReadOnly;
 use product_common::transaction::transaction_builder::Transaction;
 use tokio::sync::OnceCell;
@@ -43,7 +43,7 @@ use crate::error::Error;
 /// ```rust,no_run
 /// # use notarization::core::transactions::UpdateState;
 /// # use notarization::core::types::State;
-/// # use iota_interaction::types::base_types::ObjectID;
+/// # use iota_sdk_types::ObjectId;
 /// # use std::str::FromStr;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let new_state = State::from_string(
@@ -51,14 +51,14 @@ use crate::error::Error;
 ///     Some("Second revision".to_string()),
 /// );
 ///
-/// let object_id = ObjectID::from_str("0x123...")?;
+/// let object_id = ObjectId::from_str("0x123...")?;
 /// let update_tx = UpdateState::new(new_state, object_id);
 /// # Ok(())
 /// # }
 /// ```
 pub struct UpdateState {
     state: State,
-    object_id: ObjectID,
+    object_id: ObjectId,
     cached_ptb: OnceCell<ProgrammableTransaction>,
 }
 
@@ -69,7 +69,7 @@ impl UpdateState {
     ///
     /// - `state`: The new state to set
     /// - `object_id`: The ID of the notarization to update
-    pub fn new(state: State, object_id: ObjectID) -> Self {
+    pub fn new(state: State, object_id: ObjectId) -> Self {
         Self {
             state,
             object_id,

--- a/notarization-rs/src/core/types/event.rs
+++ b/notarization-rs/src/core/types/event.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_interaction::types::base_types::ObjectID;
+use iota_sdk_types::ObjectId;
 use serde::{Deserialize, Serialize};
 /// An event emitted by notarization operations.
 ///
@@ -15,11 +15,11 @@ pub struct Event<D> {
 /// An event that is emitted when a new dynamic notarization is created.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct DynamicNotarizationCreated {
-    pub notarization_id: ObjectID,
+    pub notarization_id: ObjectId,
 }
 
 /// An event that is emitted when a new locked notarization is created.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct LockedNotarizationCreated {
-    pub notarization_id: ObjectID,
+    pub notarization_id: ObjectId,
 }

--- a/notarization-rs/src/core/types/state.rs
+++ b/notarization-rs/src/core/types/state.rs
@@ -44,9 +44,8 @@ use std::str::FromStr;
 
 use iota_interaction::ident_str;
 use iota_interaction::types::MOVE_STDLIB_PACKAGE_ID;
-use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_interaction::types::transaction::Argument;
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::super::move_utils;
@@ -237,7 +236,7 @@ impl State {
     pub(in crate::core) fn into_ptb(
         self,
         ptb: &mut ProgrammableTransactionBuilder,
-        package_id: ObjectID,
+        package_id: ObjectId,
     ) -> Result<Argument, Error> {
         match self.data {
             Data::Bytes(data) => state_from_bytes(ptb, data, self.metadata, package_id),
@@ -251,7 +250,7 @@ fn state_from_bytes(
     ptb: &mut ProgrammableTransactionBuilder,
     data: Vec<u8>,
     metadata: Option<String>,
-    package_id: ObjectID,
+    package_id: ObjectId,
 ) -> Result<Argument, Error> {
     let data = move_utils::ptb_pure(ptb, "data", data)?;
     let metadata = move_utils::ptb_pure(ptb, "metadata", metadata)?;
@@ -270,7 +269,7 @@ fn state_from_string(
     ptb: &mut ProgrammableTransactionBuilder,
     data: String,
     metadata: Option<String>,
-    package_id: ObjectID,
+    package_id: ObjectId,
 ) -> Result<Argument, Error> {
     let data = move_utils::ptb_pure(ptb, "data", data)?;
     let metadata = move_utils::ptb_pure(ptb, "metadata", metadata)?;

--- a/notarization-rs/src/core/types/timelock.rs
+++ b/notarization-rs/src/core/types/timelock.rs
@@ -18,10 +18,9 @@
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
+use iota_sdk_types::{Argument, ObjectId, TypeTag};
 use serde::{Deserialize, Serialize};
 
 use super::super::move_utils;
@@ -91,7 +90,7 @@ impl TimeLock {
     /// Creates a new `Argument` from the `TimeLock`.
     ///
     /// To be used when creating a new `Notarization` object on the ledger.
-    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+    pub(in crate::core) fn to_ptb(&self, ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
         match self {
             TimeLock::UnlockAt(unlock_time) => new_unlock_at(ptb, *unlock_time, package_id),
             TimeLock::UntilDestroyed => new_until_destroyed(ptb, package_id),
@@ -101,7 +100,7 @@ impl TimeLock {
 }
 
 /// Creates a new `Argument` for the `unlock_at` function.
-pub(super) fn new_unlock_at(ptb: &mut Ptb, unlock_time_sec: u32, package_id: ObjectID) -> Result<Argument, Error> {
+pub(super) fn new_unlock_at(ptb: &mut Ptb, unlock_time_sec: u32, package_id: ObjectId) -> Result<Argument, Error> {
     let clock = move_utils::get_clock_ref(ptb);
     let unlock_time_sec = move_utils::ptb_pure(ptb, "unlock_time", unlock_time_sec)?;
 
@@ -115,7 +114,7 @@ pub(super) fn new_unlock_at(ptb: &mut Ptb, unlock_time_sec: u32, package_id: Obj
 }
 
 /// Creates a new `Argument` for the `until_destroyed` function.
-pub(super) fn new_until_destroyed(ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+pub(super) fn new_until_destroyed(ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
     Ok(ptb.programmable_move_call(
         package_id,
         ident_str!("timelock").as_str().into(),
@@ -126,7 +125,7 @@ pub(super) fn new_until_destroyed(ptb: &mut Ptb, package_id: ObjectID) -> Result
 }
 
 /// Creates a new `Argument` for the `none` function.
-pub(super) fn new_none(ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, Error> {
+pub(super) fn new_none(ptb: &mut Ptb, package_id: ObjectId) -> Result<Argument, Error> {
     Ok(ptb.programmable_move_call(
         package_id,
         ident_str!("timelock").as_str().into(),
@@ -137,7 +136,7 @@ pub(super) fn new_none(ptb: &mut Ptb, package_id: ObjectID) -> Result<Argument, 
 }
 
 impl MoveType for TimeLock {
-    fn move_type(package: ObjectID) -> TypeTag {
+    fn move_type(package: ObjectId) -> TypeTag {
         TypeTag::from_str(format!("{package}::timelock::TimeLock").as_str()).expect("failed to create type tag")
     }
 }

--- a/notarization-rs/tests/e2e/client.rs
+++ b/notarization-rs/tests/e2e/client.rs
@@ -4,10 +4,11 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use iota_interaction::types::base_types::{IotaAddress, ObjectID};
+use iota_interaction::types::base_types::IotaAddress;
 use iota_interaction::types::crypto::PublicKey;
 use iota_interaction::{IOTA_LOCAL_NETWORK_URL, IotaClientBuilder, KeytoolSigner};
 use iota_interaction_rust::IotaClientAdapter;
+use iota_sdk_types::ObjectId;
 use notarization::client::{NotarizationClient, NotarizationClientReadOnly};
 use product_common::core_client::{CoreClient, CoreClientReadOnly};
 use product_common::network_name::NetworkName;
@@ -22,7 +23,7 @@ pub const PUBLISH_SCRIPT_FILE: &str = concat!(
     "/../notarization-move/scripts/publish_package.sh"
 );
 
-static PACKAGE_ID: OnceCell<ObjectID> = OnceCell::const_new();
+static PACKAGE_ID: OnceCell<ObjectId> = OnceCell::const_new();
 
 pub async fn get_funded_test_client() -> anyhow::Result<TestClient> {
     TestClient::new().await
@@ -69,7 +70,7 @@ impl TestClient {
 }
 
 impl CoreClientReadOnly for TestClient {
-    fn package_id(&self) -> ObjectID {
+    fn package_id(&self) -> ObjectId {
         self.client.package_id()
     }
 


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] All `iota-rust-sdk.git` dependencies: Update to rev = 35a27488b887e28e844a1e46d7edb78605871155
- notarization_wasm:
  - [ ] New peerDep. version for @iota/iota-sdk: _
  - [ ] New dependency version for @iota/iota-interaction-ts: _
- audit_trail_wasm:
  - [ ] New peerDep. version for @iota/iota-sdk: _
  - [ ] New dependency version for @iota/iota-interaction-ts: _
- [x] pin all product-core.git dependencies to `tag = "v0.8.21"`
- [x] pin all iota.git dependencies to `tag = "v1.25.0"`

The `ObjectID` type, that has been provided by the monorepo Rust SDK, has been replaced by the `ObjectId` type from the new standalone Rust SDK, which is a breaking change for all monorepo Rust SDK users (introduced with Commit e7c394b in the iota.git repo).

Therefore, Rust code in this repository using the obsolete `ObjectID` type,  has been switched from using `iota_sdk::types::base_types::ObjectID` to use `iota_sdk_types::ObjectId` and all `ObjectID` type specifiers have been renamed to `ObjectId`.

The following types, previously imported from th eold monorepo Rust SDK are now imported from the new `iota_sdk_types` Rust SDK:
```
use iota_sdk_types::{ObjectId, Argument, TypeTag, StructTag, Owner, MakeMoveVector, Identifier, Command};
```

Rust users of the Trust Framework will also need to migrate their code in the same way.

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67