### PR TITLE
Fix `fix_docs` npm script in notarization_wasm and audit_trail_wasm

### DIFF
--- a/bindings/wasm/audit_trail_wasm/package.json
+++ b/bindings/wasm/audit_trail_wasm/package.json
@@ -33,7 +33,7 @@
     "example:web": "npm i --prefix ./cypress/app/ && npm run dev --prefix ./cypress/app/ -- --host",
     "cypress": "cypress open",
     "fmt": "dprint fmt",
-    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -E -i.bak -e 's/(\\.md?#([^#]*)?)#/\\1/' {} ';' -exec rm {}.bak ';'"
+    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -E -i.bak -e 's/\\.(md?)#([^#)]*)#([^#)]*)\\)/.\\1#\\2\\3)/g' {} ';' -exec rm {}.bak ';'"
   },
   "publishConfig": {
     "access": "public"

--- a/bindings/wasm/notarization_wasm/package.json
+++ b/bindings/wasm/notarization_wasm/package.json
@@ -36,7 +36,7 @@
     "test:unit:node": "ts-mocha -p tsconfig.node.json ./tests/*.ts --parallel --exit",
     "cypress": "cypress open",
     "fmt": "dprint fmt",
-    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -E -i.bak -e 's/(\\.md?#([^#]*)?)#/\\1/' {} ';' -exec rm {}.bak ';'"
+    "fix_docs": "find ./docs/wasm/ -type f -name '*.md' -exec sed -E -i.bak -e 's/\\.(md?)#([^#)]*)#([^#)]*)\\)/.\\1#\\2\\3)/g' {} ';' -exec rm {}.bak ';'"
   },
   "config": {
     "CYPRESS_VERIFY_TIMEOUT": 100000


### PR DESCRIPTION
# Description of change

The purpose of the `fix_docs` script is to remove hashes out of anchor identifiers in markdown links. For example the field name `x5t#s256` (used in the identity.git repo) contains a hash. Browsers strip out the hash when forming the anchor text: `x5ts256`.

The resulting markdown link in the JS/TS docs needs to be `[`x5t#S256`](IJwk.md#x5ts256)`.

The previous script version failed when two markdown links where placed in the same line resulting in a broken second MD link. The new version will distinguish the two MD links and properly produce anchor identifiers like `x5ts256`.

The new `fix_docs` script version will fail if field names contain two or more hashes (i.e. `x5t#s256#foo#bar`). This will remain unprocessed.

Please also node the equivalent IOTA Identity PR: https://github.com/iotaledger/identity/pull/1829

## Links to any relevant issues

Fixes #282
