### PR TITLE
Release: Audit Trails Version 0.1.2

### DIFF
--- a/audit-trail-rs/Cargo.toml
+++ b/audit-trail-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit_trails"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/bindings/wasm/audit_trail_wasm/Cargo.toml
+++ b/bindings/wasm/audit_trail_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit_trail_wasm"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://www.iota.org"


### PR DESCRIPTION
# Description of change

Bump cargo versions for Audit Trails packages to 0.1.2